### PR TITLE
fix: support CORS

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 #----------- Docker compose name --------------#
-COMPOSE_PROJECT_NAME=instill
+COMPOSE_PROJECT_NAME=instill-vdp
 
 #----------- Container build ------------------#
 DOCKER_BUILDKIT=1

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -32,9 +32,42 @@ import (
 	mgmtPB "github.com/instill-ai/protogen-go/mgmt/v1alpha"
 )
 
-func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler) http.Handler {
+// contains checks if a string is present in a slice
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
+// preflightHandler adds the necessary headers in order to serve
+// CORS from any origin using the methods "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"
+func preflightHandler(w http.ResponseWriter) {
+	headers := []string{"Content-Type", "Accept", "Authorization"}
+	w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
+	methods := []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}
+	w.Header().Set("Access-Control-Allow-Methods", strings.Join(methods, ","))
+}
+
+// allowCORS allows Cross Origin Resource Sharing from given origin.
+// TODO: current function does not allow using wildcard * for subdomains
+func allowCors(w http.ResponseWriter, r *http.Request, CORSOrigins []string) {
+	if origin := r.Header.Get("Origin"); origin != "" && contains(CORSOrigins, origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
+			preflightHandler(w)
+		}
+	}
+}
+
+func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler, CORSOrigins []string) http.Handler {
 	return h2c.NewHandler(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// CORS
+			allowCors(w, r, CORSOrigins)
+
 			if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
 				grpcServer.ServeHTTP(w, r)
 			} else {
@@ -132,9 +165,12 @@ func main() {
 		logger.Fatal(err.Error())
 	}
 
+	// Allowed domains are separated by ","
+	CORSOrigins := strings.Split(configs.Config.Server.CORSOrigins, ",")
+
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%v", configs.Config.Server.Port),
-		Handler: grpcHandlerFunc(grpcS, gwS),
+		Handler: grpcHandlerFunc(grpcS, gwS, CORSOrigins),
 	}
 
 	// Wait for interrupt signal to gracefully shutdown the server with a timeout of 5 seconds.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -3,10 +3,7 @@ server:
   https:
     cert:   # /ssl/tls.crt
     key:    # /ssl/tls.key
-  corsorigins:
-    - http://localhost
-    - https://instill-inc.tech
-    - https://instill.tech
+  corsorigins: http://localhost:3000   # separate domains with ",";
 database:
   username: postgres
   password: password

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -30,7 +30,7 @@ type ServerConfig struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
 	}
-	CORSOrigins []string `koanf:"corsorigins"`
+	CORSOrigins string `koanf:"corsorigins"`
 	Paginate    struct {
 		Salt string `koanf:"salt"`
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     restart: unless-stopped
     environment:
       CFG_SERVER_PORT: 8080
+      CFG_SERVER_CORSORIGINS: http://localhost:3000
       CFG_DATABASE_HOST: pg_sql
       CFG_DATABASE_PORT: 5432
       CFG_DATABASE_USERNAME: postgres


### PR DESCRIPTION
Because

- support CORS to integrate with console UI

This commit

- update CORSOrigins to be string separated by ","
- support CORS ([Reference](https://github.com/grpc-ecosystem/grpc-gateway/blob/24434e22fb9734f1a62c81c4ea246125d7844645/examples/internal/gateway/handlers.go#L32))
- update project name to `instill-vdp`
