### PR TITLE
chore: resilient with non-working usage service

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -140,7 +140,7 @@ func main() {
 		}),
 	)
 
-	if !config.Config.Server.DisableUsage {
+	if !config.Config.Server.DisableUsage && usg != nil {
 		usg.StartReporter(ctx)
 	}
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -188,7 +188,7 @@ func main() {
 	case err := <-errSig:
 		logger.Error(fmt.Sprintf("Fatal error: %v\n", err))
 	case <-quitSig:
-		if !config.Config.Server.DisableUsage {
+		if !config.Config.Server.DisableUsage && usg != nil {
 			usg.TriggerSingleReporter(ctx)
 		}
 		logger.Info("Shutting down server...")

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -523,7 +523,7 @@ func (h *handler) UpdateUser(ctx context.Context, req *mgmtPB.UpdateUserRequest)
 	}
 
 	// Trigger single reporter
-	if !config.Config.Server.DisableUsage {
+	if !config.Config.Server.DisableUsage && h.usg != nil {
 		h.usg.TriggerSingleReporter(ctx)
 	}
 

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -36,12 +36,14 @@ func NewUsage(ctx context.Context, r repository.Repository, usc usagePB.UsageSer
 
 	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil
 	}
 
 	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, version)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil
 	}
 
 	return &usage{


### PR DESCRIPTION
Because

- usage service could be not available and the mgmt server should be resilient with this situation.

This commit

- check the connection to the usage service then report only have a connection
