### PR TITLE
test: update test message

### DIFF
--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -112,7 +112,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       user: constant.defaultUser,
       update_mask: "email,firstName,lastName,orgName,role,newsletterSubscription,cookieToken"
     }), {
-      'vdp.mgmt.v1alpha.MgmtPublicService/PatchAuthenticatedUser status': (r) => r && r.status == grpc.StatusOK,
+      [`[restore the default user] vdp.mgmt.v1alpha.MgmtPublicService/PatchAuthenticatedUser status`]: (r) => r && r.status == grpc.StatusOK,
     });
 
     check(client.invoke('vdp.mgmt.v1alpha.MgmtPublicService/QueryAuthenticatedUser', {}), {


### PR DESCRIPTION
Because

- we want to separate the restore to default user test to the other tests

This commit

- update the test message
