### PR TITLE
fix: ignore `create_time` and `update_time` when converting pb to db 

### DIFF
--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -1,4 +1,3 @@
-import * as constant from "./const.js";
 import * as mgmtPrivate from "./grpc-private-user.js";
 import * as mgmtPublic from "./grpc-public-user.js"
 import * as mgmtPublicWithJwt from "./grpc-public-user-with-jwt.js"
@@ -11,9 +10,7 @@ export let options = {
   },
 };
 
-export function setup() {
-  constant;
-}
+export function setup() {}
 
 export default function (data) {
   /*

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -1,4 +1,3 @@
-import * as constant from "./const.js";
 import * as mgmtPrivate from "./rest-private-user.js";
 import * as mgmtPublic from "./rest-public-user.js"
 import * as mgmtPublicWithJwt from "./rest-public-user-with-jwt.js"
@@ -11,9 +10,7 @@ export let options = {
   },
 };
 
-export function setup() {
-  constant;
-}
+export function setup() {}
 
 export default function (data) {
   /*

--- a/pkg/datamodel/convertor.go
+++ b/pkg/datamodel/convertor.go
@@ -75,9 +75,7 @@ func PBUser2DBUser(pbUser *mgmtPB.User) (*User, error) {
 
 	return &User{
 		Base: Base{
-			UID:        uid,
-			CreateTime: pbUser.GetCreateTime().AsTime(),
-			UpdateTime: pbUser.GetUpdateTime().AsTime(),
+			UID: uid,
 		},
 		ID: pbUser.GetId(),
 		OwnerType: sql.NullString{


### PR DESCRIPTION
Because

- when converting the requesting user to a database user, we should not convert the `create_time` and `update_time` fields, since they are output only

This commit

- fix convertor
