### PR TITLE
chore: remove ValidateToken() endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230427065818-59043ce9cfc1
 	github.com/instill-ai/usage-client v0.2.3-alpha
 	github.com/instill-ai/x v0.2.0-alpha.0.20230308180651-fca77e54bedb
 	github.com/jackc/pgx/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,10 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b h1:BI97L8e4pkbQVcqRyQsR9/Q1/4pXB+zFGUWOEL/hZ6U=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230426145532-8c5f3128417d h1:0kCdj1HryF01Ak+sLe3E9yY6iW6rfH4dOBx6h0t6wHY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230426145532-8c5f3128417d/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230427065818-59043ce9cfc1 h1:BeoZnAIHhZOyjqg5R+lVb70+gYfNcfWsyjLoyQ9MLM0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230427065818-59043ce9cfc1/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=
 github.com/instill-ai/usage-client v0.2.3-alpha/go.mod h1:G0bnSyJw3ul8iNTpAGNslB18Qux0aMZF08h+CRICumw=
 github.com/instill-ai/x v0.2.0-alpha.0.20230308180651-fca77e54bedb h1:h07ja5pF7mBgp1HgjbDESWIMuAo8ijcftdhWciuHD7o=

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -512,21 +512,3 @@ func (h *PrivateHandler) DeleteUserAdmin(ctx context.Context, req *mgmtPB.Delete
 	}
 	return &mgmtPB.DeleteUserAdminResponse{}, st.Err()
 }
-
-// ValidateToken validate an API token. This endpoint is not supported yet.
-func (h *PrivateHandler) ValidateToken(ctx context.Context, req *mgmtPB.ValidateTokenRequest) (*mgmtPB.ValidateTokenResponse, error) {
-	logger, _ := logger.GetZapLogger()
-
-	st, err := sterr.CreateErrorResourceInfo(
-		codes.Unimplemented,
-		"validate token not implemented error",
-		"endpoint",
-		"/tokens/{token}",
-		"",
-		"not implemented",
-	)
-	if err != nil {
-		logger.Error(err.Error())
-	}
-	return &mgmtPB.ValidateTokenResponse{}, st.Err()
-}


### PR DESCRIPTION
Because

- ValidateToken() is not useful since we only have access_token from pipeline-backend

This commit

- remove ValidateToken() endpoint
