### PR TITLE
chore: refactor integration test mode

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (connector)
         uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (model)
         uses: actions/checkout@v3
@@ -163,4 +163,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,12 @@ unit-test:       				## Run unit test
 
 .PHONY: integration-test
 integration-test:				## Run integration test
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/grpc.js --no-usage-report --quiet
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/rest.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/grpc.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/rest.js --no-usage-report --quiet
 
 .PHONY: help
 help:       	 				## Show this help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -5,27 +5,28 @@ let host
 let publicPort
 let privatePort
 
-if (__ENV.MODE == "api-gateway") {
-  // api-gateway mode for accessing api-gateway directly
+if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
+  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+}
+
+export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+
+if (__ENV.API_GATEWAY_PROTOCOL) {
+  if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
+    fail("only allow `http` or `https` for API_GATEWAY_PROTOCOL")
+  }
+  proto = __ENV.API_GATEWAY_PROTOCOL
+} else {
   proto = "http"
-  host = "api-gateway"
+}
+
+if (apiGatewayMode) {
+  // api gateway mode
+  host = __ENV.API_GATEWAY_HOST
   privatePort = 3084
-  publicPort = 8080
-} else if (__ENV.MODE == "localhost") {
-  // localhost mode for accessing api-gateway from localhost
-  proto = "http"
-  host = "localhost"
-  privatePort = 3084
-  publicPort = 8080
-} else if (__ENV.MODE == "internal") {
-  // internal mode for accessing api-gateway from container
-  proto = "http"
-  host = "host.docker.internal"
-  privatePort = 3084
-  publicPort = 8080
+  publicPort = __ENV.API_GATEWAY_PORT
 } else {
   // direct microservice mode
-  proto = "http"
   host = "mgmt-backend"
   privatePort = 3084
   publicPort = 8084

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -1,3 +1,4 @@
+import * as constant from "./const.js"
 import * as mgmtPrivate from "./grpc-private-user.js";
 import * as mgmtPublic from "./grpc-public-user.js"
 import * as mgmtPublicWithJwt from "./grpc-public-user-with-jwt.js"
@@ -17,7 +18,7 @@ export default function (data) {
    * Management API - API CALLS
    */
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
 
     // ======== Private API
     mgmtPrivate.CheckPrivateListUsersAdmin();

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -1,3 +1,4 @@
+import * as constant from "./const.js"
 import * as mgmtPrivate from "./rest-private-user.js";
 import * as mgmtPublic from "./rest-public-user.js"
 import * as mgmtPublicWithJwt from "./rest-public-user-with-jwt.js"
@@ -17,7 +18,7 @@ export default function (data) {
    * Management API - API CALLS
    */
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
 
     // ======== Private API
     mgmtPrivate.CheckPrivateListUsersAdmin();


### PR DESCRIPTION
Because

- Need to simplify the integration test mode

This commit

- Add `API_GATEWAY_HOST`, `API_GATEWAY_PORT` and `API_GATEWAY_PROTOCOL` var. to simplify the integration test setting
