### PR TITLE
refactor: update usage functions to not use global variables

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pinglin @xiaofei-du @Phelan164
+* @donch1989 @xiaofei-du @pinglin

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -126,10 +126,10 @@ func main() {
 	// Start usage reporter
 	var usg usage.Usage
 	if !config.Config.Server.DisableUsage {
-		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
+		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient(&config.Config.UsageServer)
 		if usageServiceClientConn != nil {
 			defer usageServiceClientConn.Close()
-			usg = usage.NewUsage(ctx, repository, usageServiceClient)
+			usg = usage.NewUsage(ctx, repository, usageServiceClient, config.Config.Server.Edition)
 			if usg != nil {
 				usg.StartReporter(ctx)
 			}

--- a/go.sum
+++ b/go.sum
@@ -576,10 +576,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b h1:BI97L8e4pkbQVcqRyQsR9/Q1/4pXB+zFGUWOEL/hZ6U=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230426145532-8c5f3128417d h1:0kCdj1HryF01Ak+sLe3E9yY6iW6rfH4dOBx6h0t6wHY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230426145532-8c5f3128417d/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230427065818-59043ce9cfc1 h1:BeoZnAIHhZOyjqg5R+lVb70+gYfNcfWsyjLoyQ9MLM0=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230427065818-59043ce9cfc1/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -15,18 +15,18 @@ import (
 )
 
 // InitUsageServiceClient initializes a UsageServiceClient instance
-func InitUsageServiceClient() (usagePB.UsageServiceClient, *grpc.ClientConn) {
+func InitUsageServiceClient(usageServerConfig *config.UsageServerConfig) (usagePB.UsageServiceClient, *grpc.ClientConn) {
 	logger, _ := logger.GetZapLogger()
 
 	var clientDialOpts grpc.DialOption
-	if config.Config.UsageServer.TLSEnabled {
+	if usageServerConfig.TLSEnabled {
 		tlsConfig := &tls.Config{}
 		clientDialOpts = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	} else {
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.UsageServer.Host, config.Config.UsageServer.Port), clientDialOpts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", usageServerConfig.Host, usageServerConfig.Port), clientDialOpts)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil


### PR DESCRIPTION
Because

- we want to limit the use of global variables, as it will affect reusing the packages

This commit

- update usage functions
- update code owner to @donch1989 
