### PR TITLE
chore: limit the use of global variable and update logger

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -31,7 +31,7 @@ func createDefaultUser(db *gorm.DB) error {
 		return status.Errorf(codes.Internal, "error %v", err)
 	}
 
-	r := repository.NewRepository(db, config.Config.Server.Debug)
+	r := repository.NewRepository(db)
 
 	defaultUser := datamodel.User{
 		Base:                   datamodel.Base{UID: defaultUserUID},
@@ -66,7 +66,8 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger.InitZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger()
 	defer func() {
 		// can't handle the error due to https://github.com/uber-go/zap/issues/880
 		_ = logger.Sync()

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -31,7 +31,7 @@ func createDefaultUser(db *gorm.DB) error {
 		return status.Errorf(codes.Internal, "error %v", err)
 	}
 
-	r := repository.NewRepository(db)
+	r := repository.NewRepository(db, config.Config.Server.Debug)
 
 	defaultUser := datamodel.User{
 		Base:                   datamodel.Base{UID: defaultUserUID},

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -15,8 +15,8 @@ import (
 )
 
 // InitUsageServiceClient initializes a UsageServiceClient instance
-func InitUsageServiceClient(usageServerConfig *config.UsageServerConfig) (usagePB.UsageServiceClient, *grpc.ClientConn) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+func InitUsageServiceClient(usageServerConfig *config.UsageServerConfig, debug bool) (usagePB.UsageServiceClient, *grpc.ClientConn) {
+	logger, _ := logger.GetZapLogger(debug)
 
 	var clientDialOpts grpc.DialOption
 	if usageServerConfig.TLSEnabled {

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -15,8 +15,8 @@ import (
 )
 
 // InitUsageServiceClient initializes a UsageServiceClient instance
-func InitUsageServiceClient(usageServerConfig *config.UsageServerConfig, debug bool) (usagePB.UsageServiceClient, *grpc.ClientConn) {
-	logger, _ := logger.GetZapLogger(debug)
+func InitUsageServiceClient(usageServerConfig *config.UsageServerConfig) (usagePB.UsageServiceClient, *grpc.ClientConn) {
+	logger, _ := logger.GetZapLogger()
 
 	var clientDialOpts grpc.DialOption
 	if usageServerConfig.TLSEnabled {

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -28,20 +28,18 @@ const maxPageSize = int64(100)
 type PrivateHandler struct {
 	mgmtPB.UnimplementedMgmtPrivateServiceServer
 	Service service.Service
-	debug   bool
 }
 
 // NewPrivateHandler initiates an private handler instance
-func NewPrivateHandler(s service.Service, debug bool) mgmtPB.MgmtPrivateServiceServer {
+func NewPrivateHandler(s service.Service) mgmtPB.MgmtPrivateServiceServer {
 	return &PrivateHandler{
 		Service: s,
-		debug:   debug,
 	}
 }
 
 // ListUsersAdmin lists all users
 func (h *PrivateHandler) ListUsersAdmin(ctx context.Context, req *mgmtPB.ListUsersAdminRequest) (*mgmtPB.ListUsersAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	pageSize := req.GetPageSize()
 	if pageSize == 0 {
@@ -113,7 +111,7 @@ func (h *PrivateHandler) ListUsersAdmin(ctx context.Context, req *mgmtPB.ListUse
 
 // CreateUserAdmin creates a user. This endpoint is not supported yet.
 func (h *PrivateHandler) CreateUserAdmin(ctx context.Context, req *mgmtPB.CreateUserAdminRequest) (*mgmtPB.CreateUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 	resp := &mgmtPB.CreateUserAdminResponse{}
 
 	// Return error if REQUIRED fields are not provided in the requested payload resource
@@ -168,7 +166,7 @@ func (h *PrivateHandler) CreateUserAdmin(ctx context.Context, req *mgmtPB.Create
 
 // GetUserAdmin gets a user
 func (h *PrivateHandler) GetUserAdmin(ctx context.Context, req *mgmtPB.GetUserAdminRequest) (*mgmtPB.GetUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	id := strings.TrimPrefix(req.GetName(), "users/")
 
@@ -229,7 +227,7 @@ func (h *PrivateHandler) GetUserAdmin(ctx context.Context, req *mgmtPB.GetUserAd
 
 // LookUpUserAdmin gets a user by permalink
 func (h *PrivateHandler) LookUpUserAdmin(ctx context.Context, req *mgmtPB.LookUpUserAdminRequest) (*mgmtPB.LookUpUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	uidStr := strings.TrimPrefix(req.GetPermalink(), "users/")
 	// Validation: `uid` in request is valid
@@ -305,7 +303,7 @@ func (h *PrivateHandler) LookUpUserAdmin(ctx context.Context, req *mgmtPB.LookUp
 
 // UpdateUserAdmin updates an existing user
 func (h *PrivateHandler) UpdateUserAdmin(ctx context.Context, req *mgmtPB.UpdateUserAdminRequest) (*mgmtPB.UpdateUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	reqUser := req.GetUser()
 
@@ -499,7 +497,7 @@ func (h *PrivateHandler) UpdateUserAdmin(ctx context.Context, req *mgmtPB.Update
 
 // DeleteUserAdmin deletes a user. This endpoint is not supported yet.
 func (h *PrivateHandler) DeleteUserAdmin(ctx context.Context, req *mgmtPB.DeleteUserAdminRequest) (*mgmtPB.DeleteUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -13,7 +13,6 @@ import (
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 
-	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/datamodel"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 	"github.com/instill-ai/mgmt-backend/pkg/service"
@@ -29,18 +28,20 @@ const maxPageSize = int64(100)
 type PrivateHandler struct {
 	mgmtPB.UnimplementedMgmtPrivateServiceServer
 	Service service.Service
+	debug   bool
 }
 
 // NewPrivateHandler initiates an private handler instance
-func NewPrivateHandler(s service.Service) mgmtPB.MgmtPrivateServiceServer {
+func NewPrivateHandler(s service.Service, debug bool) mgmtPB.MgmtPrivateServiceServer {
 	return &PrivateHandler{
 		Service: s,
+		debug:   debug,
 	}
 }
 
 // ListUsersAdmin lists all users
 func (h *PrivateHandler) ListUsersAdmin(ctx context.Context, req *mgmtPB.ListUsersAdminRequest) (*mgmtPB.ListUsersAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	pageSize := req.GetPageSize()
 	if pageSize == 0 {
@@ -112,7 +113,7 @@ func (h *PrivateHandler) ListUsersAdmin(ctx context.Context, req *mgmtPB.ListUse
 
 // CreateUserAdmin creates a user. This endpoint is not supported yet.
 func (h *PrivateHandler) CreateUserAdmin(ctx context.Context, req *mgmtPB.CreateUserAdminRequest) (*mgmtPB.CreateUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 	resp := &mgmtPB.CreateUserAdminResponse{}
 
 	// Return error if REQUIRED fields are not provided in the requested payload resource
@@ -167,7 +168,7 @@ func (h *PrivateHandler) CreateUserAdmin(ctx context.Context, req *mgmtPB.Create
 
 // GetUserAdmin gets a user
 func (h *PrivateHandler) GetUserAdmin(ctx context.Context, req *mgmtPB.GetUserAdminRequest) (*mgmtPB.GetUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	id := strings.TrimPrefix(req.GetName(), "users/")
 
@@ -228,7 +229,7 @@ func (h *PrivateHandler) GetUserAdmin(ctx context.Context, req *mgmtPB.GetUserAd
 
 // LookUpUserAdmin gets a user by permalink
 func (h *PrivateHandler) LookUpUserAdmin(ctx context.Context, req *mgmtPB.LookUpUserAdminRequest) (*mgmtPB.LookUpUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	uidStr := strings.TrimPrefix(req.GetPermalink(), "users/")
 	// Validation: `uid` in request is valid
@@ -304,7 +305,7 @@ func (h *PrivateHandler) LookUpUserAdmin(ctx context.Context, req *mgmtPB.LookUp
 
 // UpdateUserAdmin updates an existing user
 func (h *PrivateHandler) UpdateUserAdmin(ctx context.Context, req *mgmtPB.UpdateUserAdminRequest) (*mgmtPB.UpdateUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	reqUser := req.GetUser()
 
@@ -498,7 +499,7 @@ func (h *PrivateHandler) UpdateUserAdmin(ctx context.Context, req *mgmtPB.Update
 
 // DeleteUserAdmin deletes a user. This endpoint is not supported yet.
 func (h *PrivateHandler) DeleteUserAdmin(ctx context.Context, req *mgmtPB.DeleteUserAdminRequest) (*mgmtPB.DeleteUserAdminResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -81,15 +81,15 @@ func (h *PrivateHandler) ListUsersAdmin(ctx context.Context, req *mgmtPB.ListUse
 	}
 
 	pbUsers := []*mgmtPB.User{}
-	for _, dbUser := range dbUsers {
-		pbUser, err := datamodel.DBUser2PBUser(&dbUser)
+	for idx, _ := range dbUsers {
+		pbUser, err := datamodel.DBUser2PBUser(&dbUsers[idx])
 		if err != nil {
 			logger.Error(err.Error())
 			st, e := sterr.CreateErrorResourceInfo(
 				codes.Internal,
 				"list user error",
 				"user",
-				fmt.Sprintf("id %s", dbUser.ID),
+				fmt.Sprintf("id %s", dbUsers[idx].ID),
 				"",
 				err.Error(),
 			)

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -36,16 +36,14 @@ type PublicHandler struct {
 	mgmtPB.UnimplementedMgmtPublicServiceServer
 	Service      service.Service
 	Usg          usage.Usage
-	debug        bool
 	disableUsage bool
 }
 
 // NewPublicHandler initiates a public handler instance
-func NewPublicHandler(s service.Service, u usage.Usage, debug, disableUsage bool) mgmtPB.MgmtPublicServiceServer {
+func NewPublicHandler(s service.Service, u usage.Usage, disableUsage bool) mgmtPB.MgmtPublicServiceServer {
 	return &PublicHandler{
 		Service:      s,
 		Usg:          u,
-		debug:        debug,
 		disableUsage: disableUsage,
 	}
 }
@@ -70,7 +68,7 @@ func (h *PublicHandler) Readiness(ctx context.Context, in *mgmtPB.ReadinessReque
 
 // GetUser returns the authenticated user
 func (h *PublicHandler) GetUser(ctx context.Context) (*mgmtPB.User, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	var dbUser *datamodel.User
 	var err error
@@ -188,7 +186,7 @@ func (h *PublicHandler) QueryAuthenticatedUser(ctx context.Context, req *mgmtPB.
 // PatchAuthenticatedUser updates the authenticated user.
 // Note: this endpoint assumes the ID of the authenticated user is the default user.
 func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.PatchAuthenticatedUserRequest) (*mgmtPB.PatchAuthenticatedUserResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	reqUser := req.GetUser()
 
@@ -388,7 +386,7 @@ func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.
 
 // ExistUsername verifies if a username (ID) has been occupied
 func (h *PublicHandler) ExistUsername(ctx context.Context, req *mgmtPB.ExistUsernameRequest) (*mgmtPB.ExistUsernameResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	id := strings.TrimPrefix(req.GetName(), "users/")
 
@@ -458,7 +456,7 @@ func (h *PublicHandler) ExistUsername(ctx context.Context, req *mgmtPB.ExistUser
 
 // CreateToken creates an API token for triggering pipelines. This endpoint is not supported yet.
 func (h *PublicHandler) CreateToken(ctx context.Context, req *mgmtPB.CreateTokenRequest) (*mgmtPB.CreateTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -476,7 +474,7 @@ func (h *PublicHandler) CreateToken(ctx context.Context, req *mgmtPB.CreateToken
 
 // ListTokens lists all the API tokens of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) ListTokens(ctx context.Context, req *mgmtPB.ListTokensRequest) (*mgmtPB.ListTokensResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -494,7 +492,7 @@ func (h *PublicHandler) ListTokens(ctx context.Context, req *mgmtPB.ListTokensRe
 
 // GetToken gets an API token of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) GetToken(ctx context.Context, req *mgmtPB.GetTokenRequest) (*mgmtPB.GetTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -512,7 +510,7 @@ func (h *PublicHandler) GetToken(ctx context.Context, req *mgmtPB.GetTokenReques
 
 // DeleteToken deletes an API token of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) DeleteToken(ctx context.Context, req *mgmtPB.DeleteTokenRequest) (*mgmtPB.DeleteTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(h.debug)
+	logger, _ := logger.GetZapLogger()
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -13,7 +13,6 @@ import (
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 
-	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/datamodel"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
@@ -35,15 +34,19 @@ var immutableFields = []string{"uid", "id"}
 
 type PublicHandler struct {
 	mgmtPB.UnimplementedMgmtPublicServiceServer
-	Service service.Service
-	Usg     usage.Usage
+	Service      service.Service
+	Usg          usage.Usage
+	debug        bool
+	disableUsage bool
 }
 
 // NewPublicHandler initiates a public handler instance
-func NewPublicHandler(s service.Service, u usage.Usage) mgmtPB.MgmtPublicServiceServer {
+func NewPublicHandler(s service.Service, u usage.Usage, debug, disableUsage bool) mgmtPB.MgmtPublicServiceServer {
 	return &PublicHandler{
-		Service: s,
-		Usg:     u,
+		Service:      s,
+		Usg:          u,
+		debug:        debug,
+		disableUsage: disableUsage,
 	}
 }
 
@@ -67,7 +70,7 @@ func (h *PublicHandler) Readiness(ctx context.Context, in *mgmtPB.ReadinessReque
 
 // GetUser returns the authenticated user
 func (h *PublicHandler) GetUser(ctx context.Context) (*mgmtPB.User, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	var dbUser *datamodel.User
 	var err error
@@ -185,7 +188,7 @@ func (h *PublicHandler) QueryAuthenticatedUser(ctx context.Context, req *mgmtPB.
 // PatchAuthenticatedUser updates the authenticated user.
 // Note: this endpoint assumes the ID of the authenticated user is the default user.
 func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.PatchAuthenticatedUserRequest) (*mgmtPB.PatchAuthenticatedUserResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	reqUser := req.GetUser()
 
@@ -376,7 +379,7 @@ func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.
 	}
 
 	// Trigger single reporter right after user updated
-	if !config.Config.Server.DisableUsage && h.Usg != nil {
+	if !h.disableUsage && h.Usg != nil {
 		h.Usg.TriggerSingleReporter(context.Background())
 	}
 
@@ -385,7 +388,7 @@ func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.
 
 // ExistUsername verifies if a username (ID) has been occupied
 func (h *PublicHandler) ExistUsername(ctx context.Context, req *mgmtPB.ExistUsernameRequest) (*mgmtPB.ExistUsernameResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	id := strings.TrimPrefix(req.GetName(), "users/")
 
@@ -455,7 +458,7 @@ func (h *PublicHandler) ExistUsername(ctx context.Context, req *mgmtPB.ExistUser
 
 // CreateToken creates an API token for triggering pipelines. This endpoint is not supported yet.
 func (h *PublicHandler) CreateToken(ctx context.Context, req *mgmtPB.CreateTokenRequest) (*mgmtPB.CreateTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -473,7 +476,7 @@ func (h *PublicHandler) CreateToken(ctx context.Context, req *mgmtPB.CreateToken
 
 // ListTokens lists all the API tokens of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) ListTokens(ctx context.Context, req *mgmtPB.ListTokensRequest) (*mgmtPB.ListTokensResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -491,7 +494,7 @@ func (h *PublicHandler) ListTokens(ctx context.Context, req *mgmtPB.ListTokensRe
 
 // GetToken gets an API token of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) GetToken(ctx context.Context, req *mgmtPB.GetTokenRequest) (*mgmtPB.GetTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,
@@ -509,7 +512,7 @@ func (h *PublicHandler) GetToken(ctx context.Context, req *mgmtPB.GetTokenReques
 
 // DeleteToken deletes an API token of the authenticated user. This endpoint is not supported yet.
 func (h *PublicHandler) DeleteToken(ctx context.Context, req *mgmtPB.DeleteTokenRequest) (*mgmtPB.DeleteTokenResponse, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(h.debug)
 
 	st, err := sterr.CreateErrorResourceInfo(
 		codes.Unimplemented,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,9 +12,7 @@ var logger *zap.Logger
 var once sync.Once
 var core zapcore.Core
 
-// GetZapLogger returns an instance of zap logger
-func GetZapLogger(debug bool) (*zap.Logger, error) {
-	var err error
+func InitZapLogger(debug bool) {
 	once.Do(func() {
 		// debug and info level enabler
 		debugInfoLevel := zap.LevelEnablerFunc(func(level zapcore.Level) bool {
@@ -62,6 +60,9 @@ func GetZapLogger(debug bool) (*zap.Logger, error) {
 		// finally construct the logger with the tee core
 		logger = zap.New(core)
 	})
+}
 
-	return logger, err
+// GetZapLogger returns an instance of zap logger
+func GetZapLogger() (*zap.Logger, error) {
+	return logger, nil
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,13 +16,13 @@ var core zapcore.Core
 func GetZapLogger(debug bool) (*zap.Logger, error) {
 	var err error
 	once.Do(func() {
-		// info level enabler
-		infoLevel := zap.LevelEnablerFunc(func(level zapcore.Level) bool {
-			return level == zapcore.InfoLevel
+		// debug and info level enabler
+		debugInfoLevel := zap.LevelEnablerFunc(func(level zapcore.Level) bool {
+			return level == zapcore.DebugLevel || level == zapcore.InfoLevel
 		})
 
-		// error and fatal level enabler
-		errorFatalLevel := zap.LevelEnablerFunc(func(level zapcore.Level) bool {
+		// warn, error and fatal level enabler
+		warnErrorFatalLevel := zap.LevelEnablerFunc(func(level zapcore.Level) bool {
 			return level == zapcore.WarnLevel || level == zapcore.ErrorLevel || level == zapcore.FatalLevel
 		})
 
@@ -36,12 +36,12 @@ func GetZapLogger(debug bool) (*zap.Logger, error) {
 				zapcore.NewCore(
 					zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig()),
 					stdoutSyncer,
-					infoLevel,
+					debugInfoLevel,
 				),
 				zapcore.NewCore(
 					zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig()),
 					stderrSyncer,
-					errorFatalLevel,
+					warnErrorFatalLevel,
 				),
 			)
 		} else {
@@ -49,12 +49,12 @@ func GetZapLogger(debug bool) (*zap.Logger, error) {
 				zapcore.NewCore(
 					zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 					stdoutSyncer,
-					infoLevel,
+					debugInfoLevel,
 				),
 				zapcore.NewCore(
 					zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 					stderrSyncer,
-					errorFatalLevel,
+					warnErrorFatalLevel,
 				),
 			)
 		}

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 )
@@ -71,7 +70,7 @@ func HttpResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Me
 
 // ErrorHandler is a callback function for gRPC-Gateway runtime.WithErrorHandler
 func ErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger()
 
 	// return Internal when Marshal failed
 	const fallback = `{"code": 13, "message": "failed to marshal error message"}`

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 
-	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/datamodel"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 	"github.com/instill-ai/x/paginate"
@@ -29,13 +28,15 @@ type Repository interface {
 }
 
 type repository struct {
-	db *gorm.DB
+	db    *gorm.DB
+	debug bool
 }
 
 // NewRepository initiates a repository instance
-func NewRepository(db *gorm.DB) Repository {
+func NewRepository(db *gorm.DB, debug bool) Repository {
 	return &repository{
-		db: db,
+		db:    db,
+		debug: debug,
 	}
 }
 
@@ -44,7 +45,7 @@ func NewRepository(db *gorm.DB) Repository {
 //   - codes.InvalidArgument
 //   - codes.Internal
 func (r *repository) ListUser(pageSize int, pageToken string) ([]datamodel.User, string, int64, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	totalSize := int64(0)
 	if result := r.db.Model(&datamodel.User{}).Count(&totalSize); result.Error != nil {
 		logger.Error(result.Error.Error())
@@ -101,7 +102,7 @@ func (r *repository) ListUser(pageSize int, pageToken string) ([]datamodel.User,
 // Return error types
 //   - codes.Internal
 func (r *repository) CreateUser(user *datamodel.User) error {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	if result := r.db.Model(&datamodel.User{}).Create(user); result.Error != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) {
@@ -130,7 +131,7 @@ func (r *repository) GetUser(uid uuid.UUID) (*datamodel.User, error) {
 // Return error types
 //   - codes.Internal
 func (r *repository) GetAllUsers() ([]datamodel.User, error) {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	var users []datamodel.User
 	if result := r.db.Find(&users); result.Error != nil {
 		logger.Error(result.Error.Error())
@@ -154,7 +155,7 @@ func (r *repository) GetUserByID(id string) (*datamodel.User, error) {
 // Return error types
 //   - codes.Internal
 func (r *repository) UpdateUser(uid uuid.UUID, user *datamodel.User) error {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	if result := r.db.Select("*").Omit("UID").Model(&datamodel.User{}).Where("uid = ?", uid.String()).Updates(user); result.Error != nil {
 		logger.Error(result.Error.Error())
 		return status.Errorf(codes.Internal, "error %v", result.Error)
@@ -167,7 +168,7 @@ func (r *repository) UpdateUser(uid uuid.UUID, user *datamodel.User) error {
 //   - codes.NotFound
 //   - codes.Internal
 func (r *repository) DeleteUser(uid uuid.UUID) error {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	result := r.db.Model(&datamodel.User{}).Where("uid = ?", uid.String()).Delete(&datamodel.User{})
 
 	if result.Error != nil {
@@ -187,7 +188,7 @@ func (r *repository) DeleteUser(uid uuid.UUID) error {
 //   - codes.NotFound
 //   - codes.Internal
 func (r *repository) DeleteUserByID(id string) error {
-	logger, _ := logger.GetZapLogger(config.Config.Server.Debug)
+	logger, _ := logger.GetZapLogger(r.debug)
 	result := r.db.Model(&datamodel.User{}).
 		Where("id = ?", id).
 		Delete(&datamodel.User{})

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -28,15 +28,13 @@ type Repository interface {
 }
 
 type repository struct {
-	db    *gorm.DB
-	debug bool
+	db *gorm.DB
 }
 
 // NewRepository initiates a repository instance
-func NewRepository(db *gorm.DB, debug bool) Repository {
+func NewRepository(db *gorm.DB) Repository {
 	return &repository{
-		db:    db,
-		debug: debug,
+		db: db,
 	}
 }
 
@@ -45,7 +43,7 @@ func NewRepository(db *gorm.DB, debug bool) Repository {
 //   - codes.InvalidArgument
 //   - codes.Internal
 func (r *repository) ListUser(pageSize int, pageToken string) ([]datamodel.User, string, int64, error) {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	totalSize := int64(0)
 	if result := r.db.Model(&datamodel.User{}).Count(&totalSize); result.Error != nil {
 		logger.Error(result.Error.Error())
@@ -102,7 +100,7 @@ func (r *repository) ListUser(pageSize int, pageToken string) ([]datamodel.User,
 // Return error types
 //   - codes.Internal
 func (r *repository) CreateUser(user *datamodel.User) error {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	if result := r.db.Model(&datamodel.User{}).Create(user); result.Error != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) {
@@ -131,7 +129,7 @@ func (r *repository) GetUser(uid uuid.UUID) (*datamodel.User, error) {
 // Return error types
 //   - codes.Internal
 func (r *repository) GetAllUsers() ([]datamodel.User, error) {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	var users []datamodel.User
 	if result := r.db.Find(&users); result.Error != nil {
 		logger.Error(result.Error.Error())
@@ -155,7 +153,7 @@ func (r *repository) GetUserByID(id string) (*datamodel.User, error) {
 // Return error types
 //   - codes.Internal
 func (r *repository) UpdateUser(uid uuid.UUID, user *datamodel.User) error {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	if result := r.db.Select("*").Omit("UID").Model(&datamodel.User{}).Where("uid = ?", uid.String()).Updates(user); result.Error != nil {
 		logger.Error(result.Error.Error())
 		return status.Errorf(codes.Internal, "error %v", result.Error)
@@ -168,7 +166,7 @@ func (r *repository) UpdateUser(uid uuid.UUID, user *datamodel.User) error {
 //   - codes.NotFound
 //   - codes.Internal
 func (r *repository) DeleteUser(uid uuid.UUID) error {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	result := r.db.Model(&datamodel.User{}).Where("uid = ?", uid.String()).Delete(&datamodel.User{})
 
 	if result.Error != nil {
@@ -188,7 +186,7 @@ func (r *repository) DeleteUser(uid uuid.UUID) error {
 //   - codes.NotFound
 //   - codes.Internal
 func (r *repository) DeleteUserByID(id string) error {
-	logger, _ := logger.GetZapLogger(r.debug)
+	logger, _ := logger.GetZapLogger()
 	result := r.db.Model(&datamodel.User{}).
 		Where("id = ?", id).
 		Delete(&datamodel.User{})

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -65,8 +65,8 @@ func (u *usage) RetrieveUsageData() interface{} {
 	}
 
 	pbUsers := []*mgmtPB.User{}
-	for _, v := range dbUsers {
-		pbUser, err := datamodel.DBUser2PBUser(&v)
+	for idx, _ := range dbUsers {
+		pbUser, err := datamodel.DBUser2PBUser(&dbUsers[idx])
 		if err != nil {
 			logger.Error(fmt.Sprintf("%s", err))
 		}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -28,12 +28,11 @@ type usage struct {
 	reporter   usageReporter.Reporter
 	edition    string
 	version    string
-	debug      bool
 }
 
 // NewUsage initiates a usage instance
-func NewUsage(ctx context.Context, r repository.Repository, usc usagePB.UsageServiceClient, edition string, debug bool) Usage {
-	logger, _ := logger.GetZapLogger(debug)
+func NewUsage(ctx context.Context, r repository.Repository, usc usagePB.UsageServiceClient, edition string) Usage {
+	logger, _ := logger.GetZapLogger()
 
 	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
 	if err != nil {
@@ -52,13 +51,12 @@ func NewUsage(ctx context.Context, r repository.Repository, usc usagePB.UsageSer
 		reporter:   reporter,
 		edition:    edition,
 		version:    version,
-		debug:      debug,
 	}
 }
 
 // RetrieveUsageData retrieves the server's usage data
 func (u *usage) RetrieveUsageData() interface{} {
-	logger, _ := logger.GetZapLogger(u.debug)
+	logger, _ := logger.GetZapLogger()
 	logger.Debug("[mgmt-backend] retrieve usage data...")
 
 	dbUsers, err := u.repository.GetAllUsers()
@@ -91,7 +89,7 @@ func (u *usage) StartReporter(ctx context.Context) {
 		return
 	}
 
-	logger, _ := logger.GetZapLogger(u.debug)
+	logger, _ := logger.GetZapLogger()
 	go func() {
 		time.Sleep(5 * time.Second)
 		err := usageClient.StartReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, u.edition, u.version, u.RetrieveUsageData)
@@ -105,7 +103,7 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	if u.reporter == nil {
 		return
 	}
-	logger, _ := logger.GetZapLogger(u.debug)
+	logger, _ := logger.GetZapLogger()
 	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, u.edition, u.version, u.RetrieveUsageData())
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -75,7 +75,9 @@ func (u *usage) RetrieveUsageData() interface{} {
 		pbUsers = append(pbUsers, pbUser)
 	}
 
-	logger.Debug("[mgmt-backend] send retrieved usage data...")
+	logger.Debug(fmt.Sprintf("[mgmt-backend] usage data length: %v", len(pbUsers)))
+
+	logger.Debug("[mgmt-backend] send usage data...")
 
 	return &usagePB.SessionReport_MgmtUsageData{
 		MgmtUsageData: &usagePB.MgmtUsageData{

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -59,7 +59,7 @@ func NewUsage(ctx context.Context, r repository.Repository, usc usagePB.UsageSer
 // RetrieveUsageData retrieves the server's usage data
 func (u *usage) RetrieveUsageData() interface{} {
 	logger, _ := logger.GetZapLogger(u.debug)
-	logger.Debug("Retrieve usage data...")
+	logger.Debug("[mgmt-backend] retrieve usage data...")
 
 	dbUsers, err := u.repository.GetAllUsers()
 	if err != nil {
@@ -75,7 +75,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 		pbUsers = append(pbUsers, pbUser)
 	}
 
-	logger.Debug("Send retrieved usage data...")
+	logger.Debug("[mgmt-backend] send retrieved usage data...")
 
 	return &usagePB.SessionReport_MgmtUsageData{
 		MgmtUsageData: &usagePB.MgmtUsageData{
@@ -107,5 +107,7 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, u.edition, u.version, u.RetrieveUsageData())
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
+	} else {
+		logger.Debug("[mgmt-backend] trigger single reporter...")
 	}
 }


### PR DESCRIPTION
Because

- the global variable is used in package functions. When importing the package, the global variable is not initialised, causing trouble
- logger requires debug level

This commit

- limit the use of global variables only in main packages
- update logger
