### PR TITLE
chore: retract accidentally published version v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/instill-ai/mgmt-backend
 
 go 1.19
 
+retract v0.3.2 // Published accidentally.
+
 require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.1


### PR DESCRIPTION
Because

- v0.3.2 is published accidentally, see https://pkg.go.dev/github.com/instill-ai/mgmt-backend/pkg/repository?tab=versions

This commit

- retract v0.3.2
