### PR TITLE
test: fix tests in direct microservice mode

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -53,6 +53,12 @@ export const restParamsWithJwtSub = {
   },
 }
 
+export const grpcParamsWithJwtSub = {
+  metadata: {
+    "Jwt-Sub": randomUUID,
+  },
+}
+
 export const defaultUser = {
   name: "users/instill-ai",
   id: "instill-ai",

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -39,14 +39,14 @@ export const mgmtPublicHost = `${proto}://${host}:${publicPort}/${mgmtVersion}`
 export const mgmtPrivateGRPCHost = `${host}:${privatePort}`
 export const mgmtPublicGRPCHost = `${host}:${publicPort}`
 
-export const params = {
+export const restParams = {
   headers: {
     "Content-Type": "application/json",
   },
 };
 
 const randomUUID = uuidv4();
-export const paramsWithJwt = {
+export const restParamsWithJwtSub = {
   headers: {
     "Content-Type": "application/json",
     "Jwt-Sub": randomUUID,

--- a/integration-test/grpc-private-user.js
+++ b/integration-test/grpc-private-user.js
@@ -344,22 +344,3 @@ export function CheckPrivateDeleteUserAdmin() {
 
   client.close();
 }
-
-export function CheckPrivateValidateToken() {
-
-  client.connect(constant.mgmtPrivateGRPCHost, {
-    plaintext: true
-  });
-
-  group(`Management Private API: Validate API token`, () => {
-
-    check(client.invoke('vdp.mgmt.v1alpha.MgmtPrivateService/ValidateToken', {
-      name: `tokens/${constant.testToken.id}`,
-    }), {
-      'vdp.mgmt.v1alpha.MgmtPrivateService/ValidateToken status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
-    });
-
-  });
-
-  client.close();
-}

--- a/integration-test/grpc-public-user-with-jwt.js
+++ b/integration-test/grpc-public-user-with-jwt.js
@@ -21,7 +21,7 @@ export function CheckPublicQueryAuthenticatedUser() {
       plaintext: true
     });
 
-    check(client.invoke('vdp.mgmt.v1alpha.MgmtPublicService/QueryAuthenticatedUser', {}, constant.paramsWithJwt), {
+    check(client.invoke('vdp.mgmt.v1alpha.MgmtPublicService/QueryAuthenticatedUser', {}, constant.grpcParamsWithJwtSub), {
       '[with random "jwt-sub" header] vdp.mgmt.v1alpha.MgmtPublicService/QueryAuthenticatedUser status StatusNotFound': (r) => r && r.status == grpc.StatusNotFound,
     });
 
@@ -52,7 +52,7 @@ export function CheckPublicPatchAuthenticatedUser() {
     check(client.invoke('vdp.mgmt.v1alpha.MgmtPublicService/PatchAuthenticatedUser', {
       user: userUpdate,
       update_mask: "email,firstName,lastName,orgName,role,newsletterSubscription,cookieToken"
-    }, constant.paramsWithJwt), {
+    }, constant.grpcParamsWithJwtSub), {
       '[with random "jwt-sub" header] vdp.mgmt.v1alpha.MgmtPublicService/PatchAuthenticatedUser status StatusNotFound': (r) => r && r.status == grpc.StatusNotFound,
     });
   });

--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -177,7 +177,7 @@ export function CheckPublicCreateToken() {
     check(client.invoke('vdp.mgmt.v1alpha.MgmtPublicService/CreateToken', {
       token: {
         id: `${constant.testToken.id}`,
-        lifetime: 86400
+        ttl: 86400
       }
     }), {
       'vdp.mgmt.v1alpha.MgmtPublicService/CreateToken status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -27,7 +27,6 @@ export default function (data) {
     mgmtPrivate.CheckPrivateLookUpUserAdmin();
     mgmtPrivate.CheckPrivateUpdateUserAdmin();
     mgmtPrivate.CheckPrivateDeleteUserAdmin();
-    mgmtPrivate.CheckPrivateValidateToken();
 
     // ======== Public API with jwt-sub
     mgmtPublicWithJwt.CheckPublicQueryAuthenticatedUser();

--- a/integration-test/proto/vdp/mgmt/v1alpha/mgmt.proto
+++ b/integration-test/proto/vdp/mgmt/v1alpha/mgmt.proto
@@ -288,10 +288,14 @@ message ApiToken {
   State state = 8  [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // API token type, value is fixed to "Bearer"
   string token_type = 9  [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
-  int64 lifetime = 10  [ (google.api.field_behavior) = INPUT_ONLY ];
-  // The amount of time (in seconds) the API token will expire. If value is -1, indicating a non-expire token
-  int64 expires_in = 11  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token expiration
+  oneof expiration {
+    // Input only. The TTL in seconds for this resource.
+    int64 ttl = 10 [(google.api.field_behavior) = INPUT_ONLY];
+
+    // API token expire time
+    google.protobuf.Timestamp expire_time = 11;
+  }
 }
 
 // CreateTokenRequest represents a request to create a API token
@@ -358,24 +362,3 @@ message DeleteTokenRequest {
 
 // DeleteTokenResponse represents an empty response
 message DeleteTokenResponse {}
-
-// ValidateTokenRequest represents a request to validate whether
-// an API token is valid to be used for triggering pipelines
-message ValidateTokenRequest {
-  // The resource name of the API token to validate,
-  // for example: "tokens/test-token"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ApiToken",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "token.name"}
-    }
-  ];
-}
-
-// ValidateTokenResponse represents a response about whether
-// the queried token is valid
-message ValidateTokenResponse {
-  // A boolean value indicating whether the token is valid
-  bool valid = 1;
-}

--- a/integration-test/proto/vdp/mgmt/v1alpha/mgmt_private_service.proto
+++ b/integration-test/proto/vdp/mgmt/v1alpha/mgmt_private_service.proto
@@ -70,14 +70,4 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // ValidateToken method receives a ValidateTokenRequest message and
-  // returns a ValidateTokenResponse
-  rpc ValidateToken(ValidateTokenRequest)
-      returns (ValidateTokenResponse) {
-    option (google.api.http) = {
-      post : "/v1alpha/{name=tokens/*}/validate"
-      body : "*"
-    };
-    option (google.api.method_signature) = "name";
-  }
 }

--- a/integration-test/rest-private-user.js
+++ b/integration-test/rest-private-user.js
@@ -400,22 +400,3 @@ export function CheckPrivateDeleteUserAdmin() {
     );
   });
 }
-
-export function CheckPrivateValidateToken() {
-  group(`Management Private API: Validate API token`, () => {
-    check(
-      http.request(
-        "POST",
-        `${constant.mgmtPrivateHost}/tokens/${constant.testToken.id}/validate`,
-        JSON.stringify({}),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
-      ),
-      {
-        [`POST /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 501 [not implemented]`]:
-          (r) => r.status === 501,
-      }
-    );
-  });
-}

--- a/integration-test/rest-private-user.js
+++ b/integration-test/rest-private-user.js
@@ -192,7 +192,7 @@ export function CheckPrivateUpdateUserAdmin() {
       http.request(
         "PATCH",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response 200`]:
           (r) => r.status === 200,
@@ -234,7 +234,7 @@ export function CheckPrivateUpdateUserAdmin() {
       http.request(
         "PATCH",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
-        JSON.stringify(constant.defaultUser), constant.params),
+        JSON.stringify(constant.defaultUser), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response status 200`]:
           (r) => r.status === 200,
@@ -261,7 +261,7 @@ export function CheckPrivateUpdateUserAdmin() {
       http.request(
         "PATCH",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response status 400`]:
           (r) => r.status === 400,
@@ -277,7 +277,7 @@ export function CheckPrivateUpdateUserAdmin() {
       http.request(
         "PATCH",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response status 400`]:
           (r) => r.status === 400,
@@ -294,7 +294,7 @@ export function CheckPrivateUpdateUserAdmin() {
       http.request(
         "PATCH",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response status 400`]:
           (r) => r.status === 400,
@@ -318,9 +318,7 @@ export function CheckPrivateCreateUserAdmin() {
         "POST",
         `${constant.mgmtPrivateHost}/admin/users`,
         JSON.stringify({ id: "2a06c2f7-8da9-4046-91ea-240f88a5d000" }),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`POST /${constant.mgmtVersion}/admin/users response status 400`]: (r) =>
@@ -334,9 +332,7 @@ export function CheckPrivateCreateUserAdmin() {
         "POST",
         `${constant.mgmtPrivateHost}/admin/users`,
         JSON.stringify({ id: "local user" }),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`POST /${constant.mgmtVersion}/admin/users response status 400`]: (r) =>
@@ -352,9 +348,7 @@ export function CheckPrivateCreateUserAdmin() {
         JSON.stringify({
           id: "instill-ai",
         }),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`POST /${constant.mgmtVersion}/admin/users response status 400`]:
@@ -370,9 +364,7 @@ export function CheckPrivateCreateUserAdmin() {
           id: "test-user",
           email: "test-user@instill.tech"
         }),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`POST /${constant.mgmtVersion}/admin/users response status 501 [not implemented]`]:
@@ -389,9 +381,7 @@ export function CheckPrivateDeleteUserAdmin() {
         "DELETE",
         `${constant.mgmtPrivateHost}/admin/users/${constant.defaultUser.id}`,
         JSON.stringify({}),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`DELETE /${constant.mgmtVersion}/admin/users/${constant.defaultUser.id} response status 501 [not implemented]`]:

--- a/integration-test/rest-public-user-with-jwt.js
+++ b/integration-test/rest-public-user-with-jwt.js
@@ -8,7 +8,7 @@ import * as helper from "./helper.js";
 export function CheckPublicQueryAuthenticatedUser() {
   group(`Management Public API: Get authenticated user [with random "jwt-sub" header]`, () => {
 
-    check(http.request("GET", `${constant.mgmtPublicHost}/users/me`, {}, constant.paramsWithJwt),
+    check(http.request("GET", `${constant.mgmtPublicHost}/users/me`, {}, constant.restParamsWithJwtSub),
       {
         [`[with random "jwt-sub" header] GET /${constant.mgmtVersion}/users/me response status 404`]:
           (r) => r.status === 404,
@@ -33,7 +33,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       update_time: "2000-01-01T00:00:00.000000Z",
     };
 
-    check(http.request("PATCH", `${constant.mgmtPublicHost}/users/me`, JSON.stringify(userUpdate), constant.paramsWithJwt),
+    check(http.request("PATCH", `${constant.mgmtPublicHost}/users/me`, JSON.stringify(userUpdate), constant.restParamsWithJwtSub),
       {
         [`[with random "jwt-sub" header] PATCH /${constant.mgmtVersion}/users/me response status 404`]: (r) => r.status === 404,
       }

--- a/integration-test/rest-public-user.js
+++ b/integration-test/rest-public-user.js
@@ -92,7 +92,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       http.request(
         "PATCH",
         `${constant.mgmtPublicHost}/users/me`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/users/me response 200`]:
           (r) => r.status === 200,
@@ -134,7 +134,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       http.request(
         "PATCH",
         `${constant.mgmtPublicHost}/users/me`,
-        JSON.stringify(constant.defaultUser), constant.params),
+        JSON.stringify(constant.defaultUser), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/users/me response status 200`]:
           (r) => r.status === 200,
@@ -161,7 +161,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       http.request(
         "PATCH",
         `${constant.mgmtPublicHost}/users/me`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/users/me response status 400`]:
           (r) => r.status === 400,
@@ -177,7 +177,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       http.request(
         "PATCH",
         `${constant.mgmtPublicHost}/users/me`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/users/me response status 400`]:
           (r) => r.status === 400,
@@ -194,7 +194,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       http.request(
         "PATCH",
         `${constant.mgmtPublicHost}/users/me`,
-        JSON.stringify(userUpdate), constant.params),
+        JSON.stringify(userUpdate), constant.restParams),
       {
         [`PATCH /${constant.mgmtVersion}/users/me response status 400`]:
           (r) => r.status === 400,
@@ -210,9 +210,7 @@ export function CheckPublicCreateToken() {
         "POST",
         `${constant.mgmtPublicHost}/tokens`,
         JSON.stringify(constant.testToken),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`POST /${constant.mgmtVersion}/tokens response status 501 [not implemented]`]:
@@ -229,9 +227,7 @@ export function CheckPublicListTokens() {
         "GET",
         `${constant.mgmtPublicHost}/tokens`,
         JSON.stringify({}),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`GET /${constant.mgmtVersion}/tokens response status 501 [not implemented]`]:
@@ -248,9 +244,7 @@ export function CheckPublicGetToken() {
         "GET",
         `${constant.mgmtPublicHost}/tokens/${constant.testToken.id}`,
         JSON.stringify({}),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`GET /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 501 [not implemented]`]:
@@ -267,9 +261,7 @@ export function CheckPublicDeleteToken() {
         "DELETE",
         `${constant.mgmtPublicHost}/tokens/${constant.testToken.id}`,
         JSON.stringify({}),
-        {
-          headers: { "Content-Type": "application/json" },
-        }
+        constant.restParams
       ),
       {
         [`DELETE /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 501 [not implemented]`]:

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -27,7 +27,6 @@ export default function (data) {
     mgmtPrivate.CheckPrivateLookUpUserAdmin();
     mgmtPrivate.CheckPrivateUpdateUserAdmin();
     mgmtPrivate.CheckPrivateDeleteUserAdmin();
-    mgmtPrivate.CheckPrivateValidateToken();
 
     // ======== Public API with jwt-sub
     mgmtPublicWithJwt.CheckPublicQueryAuthenticatedUser();


### PR DESCRIPTION
Because

- the integration tests are not up-to-date and can't be passed in microservice mode

This commit

- update the proto files
- remove tests for non-exist endpoints
- replace `headers` with `metadata` for gRPC tests to fix the k6 warning
