### PR TITLE
chore(config): add support for persistent default user uuid

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -29,9 +29,15 @@ import (
 func createDefaultUser(ctx context.Context, db *gorm.DB) error {
 
 	// Generate a random uid to the user
-	defaultUserUID, err := uuid.NewV4()
+	var defaultUserUID uuid.UUID
+	var err error
+	if config.Config.Server.DefualtUserUid != "" {
+		defaultUserUID, err = uuid.FromString(config.Config.Server.DefualtUserUid)
+	} else {
+		defaultUserUID, err = uuid.NewV4()
+	}
 	if err != nil {
-		return status.Errorf(codes.Internal, "error %v", err)
+		return status.Errorf(codes.Internal, "uuid generation error %v", err)
 	}
 
 	r := repository.NewRepository(db)

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,8 @@ type ServerConfig struct {
 		Host       string `koanf:"host"`
 		Port       int    `koanf:"port"`
 	}
-	Debug bool `koanf:"debug"`
+	Debug          bool   `koanf:"debug"`
+	DefualtUserUid string `koanf:"defaultuseruid"`
 }
 
 // DatabaseConfig related to database

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,7 @@ server:
     host: usage.instill.tech
     port: 443
   debug: true
+  defaultuseruid:
 database:
   username: postgres
   password: password


### PR DESCRIPTION
Because

- have a persistent user uuid for the default user

This commit

- add `defaultuseruuid` as config for env variable pass in
