### PR TITLE
chore(metric): add jwt injection and update chart queries

### DIFF
--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
+
+	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 )
 
 // GetRequestSingleHeader get a request header, the header has to be single-value HTTP header
@@ -157,4 +159,9 @@ func ErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.
 			}
 		}
 	}
+}
+
+func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", owner.GetUid())
+	return ctx
 }

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -7,6 +7,7 @@ import (
 	"go.einride.tech/aip/filtering"
 
 	"github.com/instill-ai/mgmt-backend/pkg/constant"
+	"github.com/instill-ai/mgmt-backend/pkg/middleware"
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
@@ -15,6 +16,8 @@ import (
 )
 
 func (s *service) pipelineUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) filtering.Filter {
+
+	ctx = middleware.InjectOwnerToContext(ctx, owner)
 
 	// lookup pipeline uid
 	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {
@@ -42,6 +45,8 @@ func (s *service) pipelineUIDLookup(ctx context.Context, filter filtering.Filter
 }
 
 func (s *service) connectorUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) filtering.Filter {
+
+	ctx = middleware.InjectOwnerToContext(ctx, owner)
 
 	// lookup connector uid
 	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {


### PR DESCRIPTION
Because

- support jwt-sub verification for api calls
- support always return current pipeline name for metric charts

This commit

- add header injection for jwt-sub
- update /charts endpoints

Resolves INS-1773