### PR TITLE
chore(metric): remove id query fallback

### DIFF
--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -277,16 +277,16 @@ func (t *Transpiler) transpileTimestampCallExpr(e *expr.Expr) (string, error) {
 }
 
 // TODO: temporary solution to recusrively find target filter expr name to replace
-func ExtractConstExpr(exprr *expr.Expr, targetName string, found bool) (string, bool) {
-	if len(exprr.GetCallExpr().GetArgs()) == 0 && exprr.GetIdentExpr().GetName() == targetName {
+func ExtractConstExpr(e *expr.Expr, targetName string, found bool) (string, bool) {
+	if len(e.GetCallExpr().GetArgs()) == 0 && e.GetIdentExpr().GetName() == targetName {
 		return "", true
 	}
 	if found {
-		return exprr.GetConstExpr().GetStringValue(), true
+		return e.GetConstExpr().GetStringValue(), true
 	}
 
 	var strValue string
-	for _, e := range exprr.GetCallExpr().GetArgs() {
+	for _, e := range e.GetCallExpr().GetArgs() {
 		strValue, found = ExtractConstExpr(e, targetName, found)
 		if strValue != "" && found {
 			return strValue, true
@@ -297,14 +297,14 @@ func ExtractConstExpr(exprr *expr.Expr, targetName string, found bool) (string, 
 }
 
 // TODO: temporary solution to hijack and replace the `pipeline_id` filter on the fly to swap to `pipeline_uid` for query
-func HijackConstExpr(exprr *expr.Expr, beforeExprName string, replaceExprName string, replaceExprValue string, found bool) (string, bool) {
-	if len(exprr.GetCallExpr().GetArgs()) == 0 && exprr.GetIdentExpr().GetName() == beforeExprName {
-		exprr.GetIdentExpr().Name = replaceExprName
+func HijackConstExpr(e *expr.Expr, beforeExprName string, replaceExprName string, replaceExprValue string, found bool) (string, bool) {
+	if len(e.GetCallExpr().GetArgs()) == 0 && e.GetIdentExpr().GetName() == beforeExprName {
+		e.GetIdentExpr().Name = replaceExprName
 		return "", true
 	}
 	if found {
-		*exprr = expr.Expr{
-			Id: exprr.GetId(),
+		*e = expr.Expr{
+			Id: e.GetId(),
 			ExprKind: &expr.Expr_ConstExpr{
 				ConstExpr: &expr.Constant{
 					ConstantKind: &expr.Constant_StringValue{
@@ -313,11 +313,11 @@ func HijackConstExpr(exprr *expr.Expr, beforeExprName string, replaceExprName st
 				},
 			},
 		}
-		return exprr.GetConstExpr().GetStringValue(), true
+		return e.GetConstExpr().GetStringValue(), true
 	}
 
 	var strValue string
-	for _, e := range exprr.GetCallExpr().GetArgs() {
+	for _, e := range e.GetCallExpr().GetArgs() {
 		strValue, found = HijackConstExpr(e, beforeExprName, replaceExprName, replaceExprValue, found)
 		if strValue != "" && found {
 			return strValue, true

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -15,7 +15,7 @@ import (
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
-func (s *service) pipelineUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) filtering.Filter {
+func (s *service) pipelineUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) (filtering.Filter, error) {
 
 	ctx = middleware.InjectOwnerToContext(ctx, owner)
 
@@ -23,28 +23,31 @@ func (s *service) pipelineUIDLookup(ctx context.Context, filter filtering.Filter
 	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {
 		pipelineID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, false)
 
-		respPipeline, err := s.pipelinePublicServiceClient.GetUserPipeline(ctx, &pipelinePB.GetUserPipelineRequest{
-			Name: fmt.Sprintf("%s/pipelines/%s", owner.Name, pipelineID),
-		})
-		if err == nil {
-			repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipeline.Pipeline.Uid, false)
+		if pipelineID != "" {
+			if respPipeline, err := s.pipelinePublicServiceClient.GetUserPipeline(ctx, &pipelinePB.GetUserPipelineRequest{
+				Name: fmt.Sprintf("%s/pipelines/%s", owner.Name, pipelineID),
+			}); err != nil {
+				return filter, err
+			} else {
+				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipeline.Pipeline.Uid, false)
 
-			// lookup pipeline release uid
-			pipelineReleaseID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineReleaseID, false)
+				// lookup pipeline release uid
+				pipelineReleaseID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineReleaseID, false)
 
-			respPipelineRelease, err := s.pipelinePublicServiceClient.GetUserPipelineRelease(ctx, &pipelinePB.GetUserPipelineReleaseRequest{
-				Name: fmt.Sprintf("%s/pipelines/%s/releases/%s", owner.Name, pipelineID, pipelineReleaseID),
-			})
-			if err == nil {
-				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipelineRelease.Release.Uid, false)
+				respPipelineRelease, err := s.pipelinePublicServiceClient.GetUserPipelineRelease(ctx, &pipelinePB.GetUserPipelineReleaseRequest{
+					Name: fmt.Sprintf("%s/pipelines/%s/releases/%s", owner.Name, pipelineID, pipelineReleaseID),
+				})
+				if err == nil {
+					repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipelineRelease.Release.Uid, false)
+				}
 			}
 		}
 	}
 
-	return filter
+	return filter, nil
 }
 
-func (s *service) connectorUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) filtering.Filter {
+func (s *service) connectorUIDLookup(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) (filtering.Filter, error) {
 
 	ctx = middleware.InjectOwnerToContext(ctx, owner)
 
@@ -52,20 +55,27 @@ func (s *service) connectorUIDLookup(ctx context.Context, filter filtering.Filte
 	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {
 		connectorID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, false)
 
-		respConnector, err := s.connectorPublicServiceClient.GetUserConnectorResource(ctx, &connectorPB.GetUserConnectorResourceRequest{
-			Name: fmt.Sprintf("%s/connectors/%s", owner.Name, connectorID),
-		})
-		if err == nil {
-			repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, constant.ConnectorUID, respConnector.ConnectorResource.Uid, false)
+		if connectorID != "" {
+			if respConnector, err := s.connectorPublicServiceClient.GetUserConnectorResource(ctx, &connectorPB.GetUserConnectorResourceRequest{
+				Name: fmt.Sprintf("%s/connectors/%s", owner.Name, connectorID),
+			}); err != nil {
+				return filter, err
+			} else {
+				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, constant.ConnectorUID, respConnector.ConnectorResource.Uid, false)
+			}
 		}
 	}
 
-	return filter
+	return filter, nil
 }
 
 func (s *service) ListPipelineTriggerRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerRecord, int64, string, error) {
 
-	filter = s.pipelineUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.pipelineUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerRecord{}, 0, "", nil
+	}
 
 	pipelineTriggerRecords, ps, pt, err := s.influxDB.QueryPipelineTriggerRecords(ctx, *owner.Uid, pageSize, pageToken, filter)
 	if err != nil {
@@ -77,7 +87,11 @@ func (s *service) ListPipelineTriggerRecords(ctx context.Context, owner *mgmtPB.
 
 func (s *service) ListPipelineTriggerTableRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerTableRecord, int64, string, error) {
 
-	filter = s.pipelineUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.pipelineUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerTableRecord{}, 0, "", nil
+	}
 
 	pipelineTriggerTableRecords, ps, pt, err := s.influxDB.QueryPipelineTriggerTableRecords(ctx, *owner.Uid, pageSize, pageToken, filter)
 	if err != nil {
@@ -89,7 +103,11 @@ func (s *service) ListPipelineTriggerTableRecords(ctx context.Context, owner *mg
 
 func (s *service) ListPipelineTriggerChartRecords(ctx context.Context, owner *mgmtPB.User, aggregationWindow int64, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerChartRecord, error) {
 
-	filter = s.pipelineUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.pipelineUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerChartRecord{}, nil
+	}
 
 	pipelineTriggerChartRecords, err := s.influxDB.QueryPipelineTriggerChartRecords(ctx, *owner.Uid, aggregationWindow, filter)
 	if err != nil {
@@ -101,9 +119,16 @@ func (s *service) ListPipelineTriggerChartRecords(ctx context.Context, owner *mg
 
 func (s *service) ListConnectorExecuteRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.ConnectorExecuteRecord, int64, string, error) {
 
-	filter = s.pipelineUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.pipelineUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.ConnectorExecuteRecord{}, 0, "", nil
+	}
 
-	filter = s.connectorUIDLookup(ctx, filter, owner)
+	filter, err = s.connectorUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.ConnectorExecuteRecord{}, 0, "", nil
+	}
 
 	connectorExecuteRecords, ps, pt, err := s.influxDB.QueryConnectorExecuteRecords(ctx, *owner.Uid, pageSize, pageToken, filter)
 	if err != nil {
@@ -115,7 +140,11 @@ func (s *service) ListConnectorExecuteRecords(ctx context.Context, owner *mgmtPB
 
 func (s *service) ListConnectorExecuteTableRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.ConnectorExecuteTableRecord, int64, string, error) {
 
-	filter = s.connectorUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.connectorUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.ConnectorExecuteTableRecord{}, 0, "", nil
+	}
 
 	connectorExecuteTableRecords, ps, pt, err := s.influxDB.QueryConnectorExecuteTableRecords(ctx, *owner.Uid, pageSize, pageToken, filter)
 	if err != nil {
@@ -127,9 +156,16 @@ func (s *service) ListConnectorExecuteTableRecords(ctx context.Context, owner *m
 
 func (s *service) ListConnectorExecuteChartRecords(ctx context.Context, owner *mgmtPB.User, aggregationWindow int64, filter filtering.Filter) ([]*mgmtPB.ConnectorExecuteChartRecord, error) {
 
-	filter = s.pipelineUIDLookup(ctx, filter, owner)
+	var err error
+	filter, err = s.pipelineUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.ConnectorExecuteChartRecord{}, nil
+	}
 
-	filter = s.connectorUIDLookup(ctx, filter, owner)
+	filter, err = s.connectorUIDLookup(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.ConnectorExecuteChartRecord{}, nil
+	}
 
 	connectorExecuteChartRecords, err := s.influxDB.QueryConnectorExecuteChartRecords(ctx, *owner.Uid, aggregationWindow, filter)
 	if err != nil {


### PR DESCRIPTION
Because

- fallback to `id` query will have the same issue as before, records mix different pipelines together

This commit

- remove logic to fallback to `id` query if `uid` lookup missed
