### PR TITLE
feat(auth): support `api_token` authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
+	"github.com/redis/go-redis/v9"
 )
 
 // Config - Global variable to export
@@ -20,6 +21,7 @@ var Config AppConfig
 type AppConfig struct {
 	Server           ServerConfig           `koanf:"server"`
 	Database         DatabaseConfig         `koanf:"database"`
+	Cache            CacheConfig            `koanf:"cache"`
 	Log              LogConfig              `koanf:"log"`
 	InfluxDB         InfluxDBConfig         `koanf:"influxdb"`
 	ConnectorBackend ConnectorBackendConfig `koanf:"connectorbackend"`
@@ -52,6 +54,13 @@ type ConnectorBackendConfig struct {
 	HTTPS      struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
+	}
+}
+
+// CacheConfig related to Redis
+type CacheConfig struct {
+	Redis struct {
+		RedisOptions redis.Options `koanf:"redisoptions"`
 	}
 }
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,6 +36,10 @@ database:
     idleconnections: 5
     maxconnections: 10
     connlifetime: 30m # In minutes, e.g., '60m'
+cache:
+  redis:
+    redisoptions:
+      addr: redis:6379
 influxdb:
   url: http://influxdb:8086
   token: i-love-instill-ai

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/knadh/koanf v1.4.4
 	github.com/mennanov/fieldmask-utils v0.5.0
+	github.com/redis/go-redis/v9 v9.2.0
 	go.einride.tech/aip v0.60.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.17.0
 	go.opentelemetry.io/otel v1.16.0
@@ -47,7 +48,9 @@ require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/catalinc/hashcash v0.0.0-20220723060415-5e3ec3e24f67 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -202,6 +204,8 @@ github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -369,6 +373,8 @@ github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.10 h1:0frpeeoM9pHouHjhLeZDuDTJ0PqjDTrycaHaMmkJAo8=
 github.com/dhui/dktest v0.3.10/go.mod h1:h5Enh0nG3Qbo9WjNFRrwmKUaePEBhXMOygbz3Ww7Sz0=
@@ -1120,6 +1126,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/redis/go-redis/v9 v9.2.0 h1:zwMdX0A4eVzse46YN18QhuDiM4uf3JmkOB4VZrdt5uI=
+github.com/redis/go-redis/v9 v9.2.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -57,10 +57,6 @@ export const defaultUser = {
 };
 
 export const testToken = {
-  name: "tokens/test-token",
   id: "test-token",
-  access_token: "at_123456",
-  state: "STATE_ACTIVE",
-  token_type: "Bearer",
-  lifetime: 86400
+  ttl: -1,
 };

--- a/integration-test/grpc-private-user.js
+++ b/integration-test/grpc-private-user.js
@@ -318,7 +318,7 @@ export function CheckPrivateCreateUserAdmin() {
         email: "test-user@instill.tech"
       }
     }), {
-      'base.mgmt.v1alpha.MgmtPrivateService/CreateUserAdmin status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPrivateService/CreateUserAdmin status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });
@@ -337,7 +337,7 @@ export function CheckPrivateDeleteUserAdmin() {
     check(client.invoke('base.mgmt.v1alpha.MgmtPrivateService/DeleteUserAdmin', {
       name: `users/${constant.defaultUser.id}`,
     }), {
-      'base.mgmt.v1alpha.MgmtPrivateService/DeleteUserAdmin status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPrivateService/DeleteUserAdmin status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });

--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -180,7 +180,7 @@ export function CheckPublicCreateToken(header) {
         ttl: 86400
       }
     }, header), {
-      'base.mgmt.v1alpha.MgmtPublicService/CreateToken status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPublicService/CreateToken status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });
@@ -197,7 +197,7 @@ export function CheckPublicListTokens(header) {
   group(`Management Public API: List API tokens`, () => {
 
     check(client.invoke('base.mgmt.v1alpha.MgmtPublicService/ListTokens', {}, header), {
-      'base.mgmt.v1alpha.MgmtPublicService/ListTokens status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPublicService/ListTokens status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });
@@ -216,7 +216,7 @@ export function CheckPublicGetToken(header) {
     check(client.invoke('base.mgmt.v1alpha.MgmtPublicService/GetToken', {
       name: `tokens/${constant.testToken.id}`,
     }, header), {
-      'base.mgmt.v1alpha.MgmtPublicService/GetToken status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPublicService/GetToken status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });
@@ -235,7 +235,7 @@ export function CheckPublicDeleteToken(header) {
     check(client.invoke('base.mgmt.v1alpha.MgmtPublicService/DeleteToken', {
       name: `tokens/${constant.testToken.id}`,
     }, header), {
-      'base.mgmt.v1alpha.MgmtPublicService/DeleteToken status StatusUnimplemented': (r) => r && r.status == grpc.StatusUnimplemented,
+      'base.mgmt.v1alpha.MgmtPublicService/DeleteToken status StatusOK': (r) => r && r.status == grpc.StatusOK,
     });
 
   });

--- a/integration-test/rest-public-user.js
+++ b/integration-test/rest-public-user.js
@@ -218,8 +218,8 @@ export function CheckPublicCreateToken(header) {
         header,
       ),
       {
-        [`POST /${constant.mgmtVersion}/tokens response status 501 [not implemented]`]:
-          (r) => r.status === 501,
+        [`POST /${constant.mgmtVersion}/tokens response status 201`]:
+          (r) => r.status === 201,
       }
     );
   });
@@ -235,8 +235,8 @@ export function CheckPublicListTokens(header) {
         header,
       ),
       {
-        [`GET /${constant.mgmtVersion}/tokens response status 501 [not implemented]`]:
-          (r) => r.status === 501,
+        [`GET /${constant.mgmtVersion}/tokens response status 200`]:
+          (r) => r.status === 200,
       }
     );
   });
@@ -252,8 +252,8 @@ export function CheckPublicGetToken(header) {
         header,
       ),
       {
-        [`GET /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 501 [not implemented]`]:
-          (r) => r.status === 501,
+        [`GET /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 200`]:
+          (r) => r.status === 200,
       }
     );
   });
@@ -269,8 +269,8 @@ export function CheckPublicDeleteToken(header) {
         header,
       ),
       {
-        [`DELETE /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 501 [not implemented]`]:
-          (r) => r.status === 501,
+        [`DELETE /${constant.mgmtVersion}/tokens/${constant.testToken.id} response status 204`]:
+          (r) => r.status === 204,
       }
     );
   });

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -23,6 +23,10 @@ const HeaderUserUIDKey = "jwt-sub"
 // MaxApiKeyNum is the maximum number of API keys
 const MaxApiKeyNum = 10
 
+const DefaultTokenType = "Bearer"
+const AccessTokenKeyFormat = "access_token:%s:owner_permalink"
+const HeaderAuthorization = "Authorization"
+
 // Filter enum
 const (
 	Start              string = "start"

--- a/pkg/datamodel/convertor.go
+++ b/pkg/datamodel/convertor.go
@@ -1,13 +1,17 @@
 package datamodel
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/instill-ai/mgmt-backend/pkg/logger"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 )
@@ -106,4 +110,67 @@ func PBUser2DBUser(pbUser *mgmtPB.User) (*User, error) {
 			Valid:  len(cookieToken) > 0,
 		},
 	}, nil
+}
+
+// DBToken2PBToken converts a database user instance to proto user
+func DBToken2PBToken(dbToken *Token) *mgmtPB.ApiToken {
+	id := dbToken.ID
+	state := mgmtPB.ApiToken_State(dbToken.State)
+	if dbToken.ExpireTime.Before(time.Now()) {
+		state = mgmtPB.ApiToken_State(mgmtPB.ApiToken_STATE_EXPIRED)
+	}
+
+	return &mgmtPB.ApiToken{
+		Name:        fmt.Sprintf("tokens/%s", id),
+		Uid:         dbToken.Base.UID.String(),
+		Id:          id,
+		State:       state,
+		AccessToken: dbToken.AccessToken,
+		TokenType:   dbToken.TokenType,
+		Expiration:  &mgmtPB.ApiToken_ExpireTime{ExpireTime: timestamppb.New(dbToken.ExpireTime)},
+		CreateTime:  timestamppb.New(dbToken.Base.CreateTime),
+		UpdateTime:  timestamppb.New(dbToken.Base.UpdateTime),
+	}
+}
+
+// PBToken2DBToken converts a proto user instance to database user
+func PBToken2DBToken(ctx context.Context, pbToken *mgmtPB.ApiToken) *Token {
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	r := &Token{
+		Base: Base{
+			UID: func() uuid.UUID {
+				if pbToken.GetUid() == "" {
+					return uuid.UUID{}
+				}
+				id, err := uuid.FromString(pbToken.GetUid())
+				if err != nil {
+					logger.Error(err.Error())
+				}
+				return id
+			}(),
+
+			CreateTime: func() time.Time {
+				if pbToken.GetCreateTime() != nil {
+					return pbToken.GetCreateTime().AsTime()
+				}
+				return time.Time{}
+			}(),
+
+			UpdateTime: func() time.Time {
+				if pbToken.GetUpdateTime() != nil {
+					return pbToken.GetUpdateTime().AsTime()
+				}
+				return time.Time{}
+			}(),
+		},
+		ID:          pbToken.GetId(),
+		State:       TokenState(pbToken.GetState()),
+		AccessToken: pbToken.AccessToken,
+		TokenType:   pbToken.TokenType,
+		ExpireTime:  pbToken.GetExpireTime().AsTime(),
+	}
+	return r
+
 }

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"gorm.io/gorm"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 )
@@ -34,15 +33,6 @@ type Base struct {
 	CreateTime time.Time `gorm:"autoCreateTime:nano;<-:create"`   // allow read and create, but not update
 	UpdateTime time.Time `gorm:"autoUpdateTime:nano"`
 	// TODO: support DeleteTime gorm.DeletedAt `sql:"index"`
-}
-
-func (base *Base) BeforeCreate(db *gorm.DB) error {
-	uuid, err := uuid.NewV4()
-	if err != nil {
-		return err
-	}
-	db.Statement.SetColumn("UID", uuid)
-	return nil
 }
 
 // User defines a user instance in the database

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -2,9 +2,30 @@ package datamodel
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"time"
 
 	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
+
+	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
+)
+
+type TokenState int32
+
+const (
+	// State: UNSPECIFIED
+	STATE_UNSPECIFIED TokenState = 0
+	// State: INACTIVE
+	STATE_INACTIVE TokenState = 1
+	// State: ACTIVE
+	STATE_ACTIVE TokenState = 2
+
+	// In db, we should use current_time < expire_tiem to determine expire or not
+	// We'll convert current_time > expire_tiem to pb's STATE_EXPIRED
+	// This can be improved when the sync between db, redis are more robust
+	// State: EXPIRED
+	// STATE_EXPIRED TokenState = 3
 )
 
 // Base contains common columns for all tables
@@ -13,6 +34,15 @@ type Base struct {
 	CreateTime time.Time `gorm:"autoCreateTime:nano;<-:create"`   // allow read and create, but not update
 	UpdateTime time.Time `gorm:"autoUpdateTime:nano"`
 	// TODO: support DeleteTime gorm.DeletedAt `sql:"index"`
+}
+
+func (base *Base) BeforeCreate(db *gorm.DB) error {
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+	db.Statement.SetColumn("UID", uuid)
+	return nil
 }
 
 // User defines a user instance in the database
@@ -38,4 +68,27 @@ type Password struct {
 
 func (Password) TableName() string {
 	return "user"
+}
+
+// Token defines a api token instance in the database
+type Token struct {
+	Base
+	ID          string
+	Owner       string
+	AccessToken string
+	State       TokenState
+	TokenType   string
+	LastUseTime time.Time
+	ExpireTime  time.Time
+}
+
+// Scan function for custom GORM type PipelineMode
+func (s *TokenState) Scan(value interface{}) error {
+	*s = TokenState(mgmtPB.ApiToken_State_value[value.(string)])
+	return nil
+}
+
+// Value function for custom GORM type PipelineMode
+func (s TokenState) Value() (driver.Value, error) {
+	return mgmtPB.ApiToken_State(s).String(), nil
 }

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 )
@@ -70,6 +71,15 @@ type Token struct {
 	TokenType   string
 	LastUseTime time.Time
 	ExpireTime  time.Time
+}
+
+func (token *Token) BeforeCreate(db *gorm.DB) error {
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+	db.Statement.SetColumn("UID", uuid)
+	return nil
 }
 
 // Scan function for custom GORM type PipelineMode

--- a/pkg/datamodel/tokengenerator.go
+++ b/pkg/datamodel/tokengenerator.go
@@ -1,0 +1,27 @@
+package datamodel
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func randomStrWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func randomStr(length int) string {
+	return randomStrWithCharset(length, charset)
+}
+func GenerateToken() string {
+	return fmt.Sprintf("instill_sk_%s", randomStr(32))
+}

--- a/pkg/db/migration/000002_init.up.sql
+++ b/pkg/db/migration/000002_init.up.sql
@@ -1,4 +1,26 @@
 BEGIN;
 ALTER TABLE public.user ADD COLUMN "password_hash" VARCHAR(255) DEFAULT '' NOT NULL;
 ALTER TABLE public.user ADD COLUMN "password_update_time" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+CREATE TYPE valid_api_token_state AS ENUM (
+  'STATE_UNSPECIFIED',
+  'STATE_INACTIVE',
+  'STATE_ACTIVE'
+);
+
+CREATE TABLE IF NOT EXISTS public.token(
+  uid UUID NOT NULL,
+  id VARCHAR(255) NOT NULL,
+  owner VARCHAR(255) NOT NULL,
+  access_token VARCHAR(255) UNIQUE,
+  state valid_api_token_state DEFAULT 'STATE_UNSPECIFIED' NOT NULL,
+  token_type VARCHAR(255),
+  last_use_time TIMESTAMPTZ NULL,
+  expire_time TIMESTAMPTZ NULL,
+  create_time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  update_time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT api_token_pkey PRIMARY KEY (uid)
+);
+CREATE UNIQUE INDEX unique_owner_id_delete_time ON public.token (owner, id);
+
 COMMIT;


### PR DESCRIPTION
Because

- we need to support `api_token`, so that the developer can build a application using `api_token` to connect Instill-Core

This commit

- support `api_token` authentication
- add tokens management endpoints
