### PR TITLE
chore(deps): adopt latest protogen-go

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -167,11 +167,6 @@ func main() {
 		grpcServerOpts = append(grpcServerOpts, grpc.Creds(creds))
 	}
 
-	connectorPublicServiceClient, connectorPublicServiceClientConn := external.InitConnectorPublicServiceClient(ctx, &config.Config)
-	if connectorPublicServiceClientConn != nil {
-		defer connectorPublicServiceClientConn.Close()
-	}
-
 	pipelinePublicServiceClient, pipelinePublicServiceClientConn := external.InitPipelinePublicServiceClient(ctx, &config.Config)
 	if pipelinePublicServiceClientConn != nil {
 		defer pipelinePublicServiceClientConn.Close()
@@ -185,7 +180,7 @@ func main() {
 
 	influxDB := repository.NewInfluxDB(influxDBQueryAPI, config.Config.InfluxDB.Bucket)
 	repository := repository.NewRepository(db)
-	service := service.NewService(repository, redisClient, influxDB, connectorPublicServiceClient, pipelinePublicServiceClient, &aclClient)
+	service := service.NewService(repository, redisClient, influxDB, pipelinePublicServiceClient, &aclClient)
 
 	// Start usage reporter
 	var usg usage.Usage

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231120083341-b8334d73ed74
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/jackc/pgx/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -749,8 +749,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231120083341-b8334d73ed74 h1:t4zILdkQzpFrWHtbnJ/pED6G84LOymdHOzMqd878tw4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231120083341-b8334d73ed74/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7 h1:vhMCJLPhVvhINR31VgOyq5ct8f7TZx2ZteQXpjGwaEc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061 h1:lOp2fORCj76/gfPuLqB3TEN2cvFRJHUQOxwFSl4qxEw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061/go.mod h1:dxsx9oHibg/+FrFLxAMurvbheeVUrMdFTbVHsfANTCU=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -19,33 +19,8 @@ import (
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 
 	usagePB "github.com/instill-ai/protogen-go/core/usage/v1alpha"
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
-
-// InitConnectorPublicServiceClient initialises a ConnectorPublicServiceClient instance
-func InitConnectorPublicServiceClient(ctx context.Context, appConfig *config.AppConfig) (connectorPB.ConnectorPublicServiceClient, *grpc.ClientConn) {
-	logger, _ := logger.GetZapLogger(ctx)
-
-	var clientDialOpts grpc.DialOption
-	if appConfig.ConnectorBackend.HTTPS.Cert != "" && appConfig.ConnectorBackend.HTTPS.Key != "" {
-		creds, err := credentials.NewServerTLSFromFile(appConfig.ConnectorBackend.HTTPS.Cert, appConfig.ConnectorBackend.HTTPS.Key)
-		if err != nil {
-			logger.Fatal(err.Error())
-		}
-		clientDialOpts = grpc.WithTransportCredentials(creds)
-	} else {
-		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
-	}
-
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", appConfig.ConnectorBackend.Host, appConfig.ConnectorBackend.PublicPort), clientDialOpts)
-	if err != nil {
-		logger.Error(err.Error())
-		return nil, nil
-	}
-
-	return connectorPB.NewConnectorPublicServiceClient(clientConn), clientConn
-}
 
 // InitPipelinePublicServiceClient initialises a PipelinePublicServiceClient instance
 func InitPipelinePublicServiceClient(ctx context.Context, appConfig *config.AppConfig) (pipelinePB.PipelinePublicServiceClient, *grpc.ClientConn) {

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -11,7 +11,6 @@ import (
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
@@ -56,12 +55,12 @@ func (s *service) connectorUIDLookup(ctx context.Context, filter filtering.Filte
 		connectorID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, false)
 
 		if connectorID != "" {
-			if respConnector, err := s.connectorPublicServiceClient.GetUserConnectorResource(ctx, &connectorPB.GetUserConnectorResourceRequest{
+			if respConnector, err := s.pipelinePublicServiceClient.GetUserConnector(ctx, &pipelinePB.GetUserConnectorRequest{
 				Name: fmt.Sprintf("%s/connectors/%s", owner.Name, connectorID),
 			}); err != nil {
 				return filter, err
 			} else {
-				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, constant.ConnectorUID, respConnector.ConnectorResource.Uid, false)
+				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.ConnectorID, constant.ConnectorUID, respConnector.Connector.Uid, false)
 			}
 		}
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
@@ -80,23 +79,21 @@ type Service interface {
 }
 
 type service struct {
-	repository                   repository.Repository
-	influxDB                     repository.InfluxDB
-	connectorPublicServiceClient connectorPB.ConnectorPublicServiceClient
-	pipelinePublicServiceClient  pipelinePB.PipelinePublicServiceClient
-	redisClient                  *redis.Client
-	aclClient                    *acl.ACLClient
+	repository                  repository.Repository
+	influxDB                    repository.InfluxDB
+	pipelinePublicServiceClient pipelinePB.PipelinePublicServiceClient
+	redisClient                 *redis.Client
+	aclClient                   *acl.ACLClient
 }
 
 // NewService initiates a service instance
-func NewService(r repository.Repository, rc *redis.Client, i repository.InfluxDB, c connectorPB.ConnectorPublicServiceClient, p pipelinePB.PipelinePublicServiceClient, acl *acl.ACLClient) Service {
+func NewService(r repository.Repository, rc *redis.Client, i repository.InfluxDB, p pipelinePB.PipelinePublicServiceClient, acl *acl.ACLClient) Service {
 	return &service{
-		repository:                   r,
-		influxDB:                     i,
-		connectorPublicServiceClient: c,
-		pipelinePublicServiceClient:  p,
-		redisClient:                  rc,
-		aclClient:                    acl,
+		repository:                  r,
+		influxDB:                    i,
+		pipelinePublicServiceClient: p,
+		redisClient:                 rc,
+		aclClient:                   acl,
 	}
 }
 


### PR DESCRIPTION
Because

- the protogen-go pkg is outdated

This commit

- adopt latest protogen-go package
