### PR TITLE
chore(middleware): do not wrap internal error

### DIFF
--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -113,6 +113,6 @@ func InjectErrCode(err error) error {
 		return status.Error(codes.InvalidArgument, err.Error())
 
 	default:
-		return status.Error(codes.Internal, err.Error())
+		return err
 	}
 }


### PR DESCRIPTION
Because

- we should not wrap internal error

This commit

- do not wrap internal error
