### PR TITLE
refactor(fga): update FGA model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231129095217-f8d4e5951d35
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231129095217-f8d4e5951d35 h1:25AKxLuDZmVJOnh+gx4tqsfS5y/woQHzh8j1J5wN0ec=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231129095217-f8d4e5951d35/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023 h1:QxE9Y/Yyw91gdyJAdvndpakGAFdGtNXyjKfvcTw0Sx8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061 h1:lOp2fORCj76/gfPuLqB3TEN2cvFRJHUQOxwFSl4qxEw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061/go.mod h1:dxsx9oHibg/+FrFLxAMurvbheeVUrMdFTbVHsfANTCU=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/acl/model.go
+++ b/pkg/acl/model.go
@@ -1,20 +1,65 @@
 package acl
 
+// model
+//   schema 1.1
+
+// type visitor
+
+// type user
+
+// type code
+
+// type organization
+//   relations
+//     define owner: [user]
+//     define member: [user] or owner
+//     define pending_owner: [user]
+//     define pending_member: [user]
+//     define can_create_organization: owner
+//     define can_delete_organization: owner
+//     define can_get_membership: owner or member
+//     define can_remove_membership: owner
+//     define can_set_membership: owner
+//     define can_update_organization: owner
+
+// type pipeline
+//   relations
+//   define owner: [organization, user]
+//     define admin: [user] or owner or member from owner
+//     define writer: [user] or admin or member from owner
+//     define executor: [user, user:*, code] or writer or member from owner
+//     define reader: [user, user:*, code, visitor:*] or executor or member from owner
+
+// type connector
+//   relations
+//     define owner: [organization, user]
+//     define admin: [user] or owner or member from owner
+//     define writer: [user] or admin or member from owner
+//     define executor: [user, user:*] or writer or member from owner
+//     define reader: [user, user:*] or executor or member from owner
+
 const ACLModel = `
-{
+  {
 	"type_definitions": [
+	  {
+		"type": "visitor",
+		"relations": {},
+		"metadata": null
+	  },
 	  {
 		"type": "user",
 		"relations": {},
 		"metadata": null
 	  },
 	  {
+		"type": "code",
+		"relations": {},
+		"metadata": null
+	  },
+	  {
 		"type": "organization",
 		"relations": {
-		  "pending_member": {
-			"this": {}
-		  },
-		  "pending_owner": {
+		  "owner": {
 			"this": {}
 		  },
 		  "member": {
@@ -32,29 +77,64 @@ const ACLModel = `
 			  ]
 			}
 		  },
-		  "owner": {
+		  "pending_owner": {
 			"this": {}
 		  },
-		  "repo_admin": {
+		  "pending_member": {
 			"this": {}
 		  },
-		  "repo_reader": {
-			"this": {}
+		  "can_create_organization": {
+			"computedUserset": {
+			  "object": "",
+			  "relation": "owner"
+			}
 		  },
-		  "repo_writer": {
-			"this": {}
+		  "can_delete_organization": {
+			"computedUserset": {
+			  "object": "",
+			  "relation": "owner"
+			}
+		  },
+		  "can_get_membership": {
+			"union": {
+			  "child": [
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "owner"
+				  }
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "member"
+				  }
+				}
+			  ]
+			}
+		  },
+		  "can_remove_membership": {
+			"computedUserset": {
+			  "object": "",
+			  "relation": "owner"
+			}
+		  },
+		  "can_set_membership": {
+			"computedUserset": {
+			  "object": "",
+			  "relation": "owner"
+			}
+		  },
+		  "can_update_organization": {
+			"computedUserset": {
+			  "object": "",
+			  "relation": "owner"
+			}
 		  }
 		},
 		"metadata": {
 		  "relations": {
-			"pending_member": {
-			  "directly_related_user_types": [
-				{
-				  "type": "user"
-				}
-			  ]
-			},
-			"pending_owner": {
+			"owner": {
 			  "directly_related_user_types": [
 				{
 				  "type": "user"
@@ -68,43 +148,377 @@ const ACLModel = `
 				}
 			  ]
 			},
+			"pending_owner": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"pending_member": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"can_create_organization": {
+			  "directly_related_user_types": []
+			},
+			"can_delete_organization": {
+			  "directly_related_user_types": []
+			},
+			"can_get_membership": {
+			  "directly_related_user_types": []
+			},
+			"can_remove_membership": {
+			  "directly_related_user_types": []
+			},
+			"can_set_membership": {
+			  "directly_related_user_types": []
+			},
+			"can_update_organization": {
+			  "directly_related_user_types": []
+			}
+		  }
+		}
+	  },
+	  {
+		"type": "pipeline",
+		"relations": {
+		  "owner": {
+			"this": {}
+		  },
+		  "admin": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "owner"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "writer": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "admin"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "executor": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "writer"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "reader": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "executor"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  }
+		},
+		"metadata": {
+		  "relations": {
 			"owner": {
 			  "directly_related_user_types": [
 				{
+				  "type": "organization"
+				},
+				{
 				  "type": "user"
 				}
 			  ]
 			},
-			"repo_admin": {
+			"admin": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"writer": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"executor": {
 			  "directly_related_user_types": [
 				{
 				  "type": "user"
 				},
 				{
-				  "type": "organization",
-				  "relation": "member"
+				  "type": "user",
+				  "wildcard": {}
+				},
+				{
+				  "type": "code"
 				}
 			  ]
 			},
-			"repo_reader": {
+			"reader": {
 			  "directly_related_user_types": [
 				{
 				  "type": "user"
 				},
 				{
-				  "type": "organization",
-				  "relation": "member"
+				  "type": "user",
+				  "wildcard": {}
+				},
+				{
+				  "type": "code"
+				},
+				{
+				  "type": "visitor",
+				  "wildcard": {}
+				}
+			  ]
+			}
+		  }
+		}
+	  },
+	  {
+		"type": "connector",
+		"relations": {
+		  "owner": {
+			"this": {}
+		  },
+		  "admin": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "owner"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "writer": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "admin"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "executor": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "writer"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "reader": {
+			"union": {
+			  "child": [
+				{
+				  "this": {}
+				},
+				{
+				  "computedUserset": {
+					"object": "",
+					"relation": "executor"
+				  }
+				},
+				{
+				  "tupleToUserset": {
+					"computedUserset": {
+					  "object": "",
+					  "relation": "member"
+					},
+					"tupleset": {
+					  "object": "",
+					  "relation": "owner"
+					}
+				  }
+				}
+			  ]
+			}
+		  }
+		},
+		"metadata": {
+		  "relations": {
+			"owner": {
+			  "directly_related_user_types": [
+				{
+				  "type": "organization"
+				},
+				{
+				  "type": "user"
 				}
 			  ]
 			},
-			"repo_writer": {
+			"admin": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"writer": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				}
+			  ]
+			},
+			"executor": {
 			  "directly_related_user_types": [
 				{
 				  "type": "user"
 				},
 				{
-				  "type": "organization",
-				  "relation": "member"
+				  "type": "user",
+				  "wildcard": {}
+				}
+			  ]
+			},
+			"reader": {
+			  "directly_related_user_types": [
+				{
+				  "type": "user"
+				},
+				{
+				  "type": "user",
+				  "wildcard": {}
 				}
 			  ]
 			}
@@ -113,5 +527,5 @@ const ACLModel = `
 	  }
 	],
 	"schema_version": "1.1"
-}
+  }
 `

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -113,7 +113,7 @@ func (h *PublicHandler) AuthTokenIssuer(ctx context.Context, in *mgmtPB.AuthToke
 
 func (h *PublicHandler) AuthChangePassword(ctx context.Context, in *mgmtPB.AuthChangePasswordRequest) (*mgmtPB.AuthChangePasswordResponse, error) {
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (h *PublicHandler) ListUsers(ctx context.Context, req *mgmtPB.ListUsersRequ
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, true)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -191,7 +191,6 @@ func (h *PublicHandler) ListUsers(ctx context.Context, req *mgmtPB.ListUsersRequ
 }
 
 // GetUser gets the user.
-// Note: this endpoint assumes the ID of the authenticated user is the default user.
 func (h *PublicHandler) GetUser(ctx context.Context, req *mgmtPB.GetUserRequest) (*mgmtPB.GetUserResponse, error) {
 
 	eventName := "GetUser"
@@ -203,7 +202,7 @@ func (h *PublicHandler) GetUser(ctx context.Context, req *mgmtPB.GetUserRequest)
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, true)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -266,7 +265,7 @@ func (h *PublicHandler) PatchAuthenticatedUser(ctx context.Context, req *mgmtPB.
 		return nil, err
 	}
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -395,7 +394,7 @@ func (h *PublicHandler) CreateOrganization(ctx context.Context, req *mgmtPB.Crea
 		return nil, ErrResourceID
 	}
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -437,7 +436,7 @@ func (h *PublicHandler) ListOrganizations(ctx context.Context, req *mgmtPB.ListO
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, true)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -474,7 +473,7 @@ func (h *PublicHandler) GetOrganization(ctx context.Context, req *mgmtPB.GetOrga
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, true)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -517,7 +516,7 @@ func (h *PublicHandler) UpdateOrganization(ctx context.Context, req *mgmtPB.Upda
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -606,7 +605,7 @@ func (h *PublicHandler) DeleteOrganization(ctx context.Context, req *mgmtPB.Dele
 		span.SetStatus(1, err.Error())
 		return nil, ErrResourceID
 	}
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -671,7 +670,7 @@ func (h *PublicHandler) CreateToken(ctx context.Context, req *mgmtPB.CreateToken
 		return &mgmtPB.CreateTokenResponse{}, ErrCheckRequiredFields
 	}
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -719,7 +718,7 @@ func (h *PublicHandler) ListTokens(ctx context.Context, req *mgmtPB.ListTokensRe
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -757,7 +756,7 @@ func (h *PublicHandler) GetToken(ctx context.Context, req *mgmtPB.GetTokenReques
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -800,7 +799,7 @@ func (h *PublicHandler) DeleteToken(ctx context.Context, req *mgmtPB.DeleteToken
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -863,7 +862,7 @@ func (h *PublicHandler) ListPipelineTriggerRecords(ctx context.Context, req *mgm
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -933,7 +932,7 @@ func (h *PublicHandler) ListPipelineTriggerTableRecords(ctx context.Context, req
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -998,7 +997,7 @@ func (h *PublicHandler) ListPipelineTriggerChartRecords(ctx context.Context, req
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1065,7 +1064,7 @@ func (h *PublicHandler) ListConnectorExecuteRecords(ctx context.Context, req *mg
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1135,7 +1134,7 @@ func (h *PublicHandler) ListConnectorExecuteTableRecords(ctx context.Context, re
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1198,7 +1197,7 @@ func (h *PublicHandler) ListConnectorExecuteChartRecords(ctx context.Context, re
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1266,7 +1265,7 @@ func (h *PublicHandler) ListUserMemberships(ctx context.Context, req *mgmtPB.Lis
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1309,7 +1308,7 @@ func (h *PublicHandler) GetUserMembership(ctx context.Context, req *mgmtPB.GetUs
 
 	userID := strings.Split(req.Name, "/")[1]
 	orgID := strings.Split(req.Name, "/")[3]
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1352,7 +1351,7 @@ func (h *PublicHandler) UpdateUserMembership(ctx context.Context, req *mgmtPB.Up
 
 	userID := strings.Split(req.Membership.Name, "/")[1]
 	orgID := strings.Split(req.Membership.Name, "/")[3]
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1403,7 +1402,7 @@ func (h *PublicHandler) DeleteUserMembership(ctx context.Context, req *mgmtPB.De
 
 	userID := strings.Split(req.Name, "/")[1]
 	orgID := strings.Split(req.Name, "/")[3]
-	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	ctxUserID, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1442,7 +1441,7 @@ func (h *PublicHandler) ListOrganizationMemberships(ctx context.Context, req *mg
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1480,7 +1479,7 @@ func (h *PublicHandler) GetOrganizationMembership(ctx context.Context, req *mgmt
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1521,7 +1520,7 @@ func (h *PublicHandler) UpdateOrganizationMembership(ctx context.Context, req *m
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1570,7 +1569,7 @@ func (h *PublicHandler) DeleteOrganizationMembership(ctx context.Context, req *m
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx)
+	_, ctxUserUID, err := h.Service.AuthenticateUser(ctx, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -3,8 +3,6 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -189,7 +187,6 @@ func (r *repository) createOwner(ctx context.Context, ownerType string, owner *d
 
 	logger, _ := logger.GetZapLogger(ctx)
 	if result := r.db.Model(&datamodel.Owner{}).Create(owner); result.Error != nil {
-		fmt.Println("errors", errors.Is(result.Error, gorm.ErrDuplicatedKey))
 		logger.Error(result.Error.Error())
 		return result.Error
 	}


### PR DESCRIPTION
Because

- We want to support pipeline and connector under organization namespace. Also, we'd like to make the public pipeline reachable without user login.

This commit

- update FGA model to support organization pipeline and connector
- update FGA model to support pipeline sharing and public pipeline
