### PR TITLE
refactor(core): retire ExistUsername API and add CheckNamespace API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204182419-7da07a835d1d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023 h1:QxE9Y/Yyw91gdyJAdvndpakGAFdGtNXyjKfvcTw0Sx8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204182419-7da07a835d1d h1:K4az4xI0sedkL7TAO1Yk/oWJ9wM1LHvVWPkf0gTGfrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204182419-7da07a835d1d/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061 h1:lOp2fORCj76/gfPuLqB3TEN2cvFRJHUQOxwFSl4qxEw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061/go.mod h1:dxsx9oHibg/+FrFLxAMurvbheeVUrMdFTbVHsfANTCU=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -254,7 +254,7 @@ export function CheckPublicMetrics(header) {
     let emptyPipelineTriggerRecordResponse = {
       "pipelineTriggerRecords": [],
       "nextPageToken": "",
-      "totalSize": "0"
+      "totalSize": 0
     }
 
     check(client.invoke('core.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerRecords', {}, header), {
@@ -279,7 +279,7 @@ export function CheckPublicMetrics(header) {
     let emptyPipelineTriggerTableRecordResponse = {
       "pipelineTriggerTableRecords": [],
       "nextPageToken": "",
-      "totalSize": "0"
+      "totalSize": 0
     }
 
     check(client.invoke('core.mgmt.v1alpha.MgmtPublicService/ListPipelineTriggerTableRecords', {}, header), {
@@ -319,7 +319,7 @@ export function CheckPublicMetrics(header) {
     let emptyConnectorExecuteRecordResponse = {
       "connectorExecuteRecords": [],
       "nextPageToken": "",
-      "totalSize": "0"
+      "totalSize": 0
     }
 
     check(client.invoke('core.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteRecords', {}, header), {
@@ -344,7 +344,7 @@ export function CheckPublicMetrics(header) {
     let emptyConnectorExecuteTableRecordResponse = {
       "connectorExecuteTableRecords": [],
       "nextPageToken": "",
-      "totalSize": "0"
+      "totalSize": 0
     }
 
     check(client.invoke('core.mgmt.v1alpha.MgmtPublicService/ListConnectorExecuteTableRecords', {}, header), {

--- a/integration-test/proto/core/mgmt/v1alpha/metric.proto
+++ b/integration-test/proto/core/mgmt/v1alpha/metric.proto
@@ -45,21 +45,31 @@ message PipelineTriggerRecord {
   float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Final status for pipeline trigger
   Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// PipelineTriggerTableRecord represents a aggregated table record for pipeline trigger
+// PipelineTriggerTableRecord represents a aggregated table record for pipeline
+// trigger
 message PipelineTriggerTableRecord {
   // ID for the triggered pipeline
   string pipeline_id = 1;
   // UID for the triggered pipeline
   string pipeline_uid = 2;
   // Trigger count with STATUS_COMPLETED
-  int64 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Trigger count with STATUS_ERRORED
-  int64 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
+// PipelineTriggerChartRecord represents a aggregated chart record for pipeline
+// trigger
 message PipelineTriggerChartRecord {
   // ID for the triggered pipeline
   string pipeline_id = 1;
@@ -72,18 +82,23 @@ message PipelineTriggerChartRecord {
   // Time buckets
   repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Aggregated trigger count in each time bucket
-  repeated int64 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total compute time duration in each time bucket
   repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelineTriggerRecordsRequest represents a request to list
 // pipeline trigger record
 message ListPipelineTriggerRecordsRequest {
-  // The maximum number of pipeline trigger record to return. The service may return
-  // fewer than this value. If unspecified, at most 100 record will be returned. The
-  // maximum value is 1000; values above 1000 will be coerced to 1000.
-  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The maximum number of pipeline trigger record to return. The service may
+  // return fewer than this value. If unspecified, at most 100 record will be
+  // returned. The maximum value is 1000; values above 1000 will be coerced to
+  // 1000.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list record
@@ -98,16 +113,17 @@ message ListPipelineTriggerRecordsResponse {
   // Next page token
   string next_page_token = 2;
   // Total count of pipeline trigger records
-  int64 total_size = 3;
+  int32 total_size = 3;
 }
 
 // ListPipelineTriggerTableRecordsRequest represents a request to list
 // pipeline trigger table record
 message ListPipelineTriggerTableRecordsRequest {
-  // The maximum number of pipeline trigger record to return. The service may return
-  // fewer than this value. If unspecified, at most 100 record will be returned. The
-  // maximum value is 1000; values above 1000 will be coerced to 1000.
-  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The maximum number of pipeline trigger record to return. The service may
+  // return fewer than this value. If unspecified, at most 100 record will be
+  // returned. The maximum value is 1000; values above 1000 will be coerced to
+  // 1000.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list record
@@ -122,14 +138,14 @@ message ListPipelineTriggerTableRecordsResponse {
   // Next page token
   string next_page_token = 2;
   // Total count of pipeline trigger records
-  int64 total_size = 3;
+  int32 total_size = 3;
 }
 
 // ListPipelineTriggerChartRecordsRequest represents a request to list
 // pipeline trigger chart record
 message ListPipelineTriggerChartRecordsRequest {
   // Aggregation window in nanoseconds
-  int64 aggregation_window = 1;
+  int32 aggregation_window = 1;
   // Filter expression to list chart record
   optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 }
@@ -167,19 +183,21 @@ message ConnectorExecuteRecord {
   Status status = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ConnectorExecuteTableRecord represents a aggregated table record for connector execute
+// ConnectorExecuteTableRecord represents a aggregated table record for
+// connector execute
 message ConnectorExecuteTableRecord {
   // ID for the executed connector
   string connector_id = 1;
   // UID for the executed connector
   string connector_uid = 2;
   // Execute count with STATUS_COMPLETED
-  int64 execute_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 execute_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Execute count with STATUS_ERRORED
-  int64 execute_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 execute_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ConnectorExecuteChartRecord represents a aggregated chart record for connector execute
+// ConnectorExecuteChartRecord represents a aggregated chart record for
+// connector execute
 message ConnectorExecuteChartRecord {
   // ID for the executed connector
   string connector_id = 1;
@@ -190,7 +208,7 @@ message ConnectorExecuteChartRecord {
   // Time buckets
   repeated google.protobuf.Timestamp time_buckets = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Aggregated execute count in each time bucket
-  repeated int64 execute_counts = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated int32 execute_counts = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total compute time duration in each time bucket
   repeated float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -198,10 +216,11 @@ message ConnectorExecuteChartRecord {
 // ListConnectorExecuteRecordsRequest represents a request to list
 // connector execute record
 message ListConnectorExecuteRecordsRequest {
-  // The maximum number of connector execution record to return. The service may return
-  // fewer than this value. If unspecified, at most 100 record will be returned. The
-  // maximum value is 1000; values above 1000 will be coerced to 1000.
-  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The maximum number of connector execution record to return. The service may
+  // return fewer than this value. If unspecified, at most 100 record will be
+  // returned. The maximum value is 1000; values above 1000 will be coerced to
+  // 1000.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list record
@@ -216,16 +235,17 @@ message ListConnectorExecuteRecordsResponse {
   // Next page token
   string next_page_token = 2;
   // Total count of connector execute records
-  int64 total_size = 3;
+  int32 total_size = 3;
 }
 
 // ListConnectorExecuteTableRecordsRequest represents a request to list
 // connector execute table record
 message ListConnectorExecuteTableRecordsRequest {
-  // The maximum number of connector execution table record to return. The service may return
-  // fewer than this value. If unspecified, at most 100 record will be returned. The
-  // maximum value is 1000; values above 1000 will be coerced to 1000.
-  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The maximum number of connector execution table record to return. The
+  // service may return fewer than this value. If unspecified, at most 100
+  // record will be returned. The maximum value is 1000; values above 1000 will
+  // be coerced to 1000.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list record
@@ -240,14 +260,14 @@ message ListConnectorExecuteTableRecordsResponse {
   // Next page token
   string next_page_token = 2;
   // Total count of connector execute records
-  int64 total_size = 3;
+  int32 total_size = 3;
 }
 
 // ListConnectorExecuteChartRecordsRequest represents a request to list
 // connector execute chart record
 message ListConnectorExecuteChartRecordsRequest {
   // Aggregation window in nanoseconds
-  int64 aggregation_window = 1;
+  int32 aggregation_window = 1;
   // Filter expression to list chart record
   optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/integration-test/proto/core/mgmt/v1alpha/mgmt.proto
+++ b/integration-test/proto/core/mgmt/v1alpha/mgmt.proto
@@ -8,6 +8,7 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protobuf standard
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -69,16 +70,6 @@ enum MembershipState {
   MEMBERSHIP_STATE_PENDING = 2;
 }
 
-// InvitationState
-enum InvitationState {
-  // Invitation: UNSPECIFIED
-  INVITATION_STATE_UNSPECIFIED = 0;
-  // Invitation: Pending
-  INVITATION_STATE_PENDING = 1;
-  // Invitation: Failed
-  INVITATION_STATE_FAILED = 2;
-}
-
 // Users
 
 // User represents the content of a user
@@ -128,6 +119,10 @@ message User {
   bool newsletter_subscription = 13 [(google.api.field_behavior) = REQUIRED];
   // User console cookie token
   optional string cookie_token = 14 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Avatar base64
+  optional string profile_avatar = 15 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Data
+  optional google.protobuf.Struct profile_data = 16 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUsersAdminRequest represents a request to list all users by admin
@@ -153,21 +148,6 @@ message ListUsersAdminResponse {
   string next_page_token = 2;
   // Total count of users
   int32 total_size = 3;
-}
-
-// CreateUserAdminRequest represents a request to create a user by admin
-message CreateUserAdminRequest {
-  // The user to be created
-  //
-  // The user's `name` field is used to identify the user to create.
-  // Format: users/{user}
-  User user = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// CreateUserAdminResponse represents a response for a user response
-message CreateUserAdminResponse {
-  // A user resource
-  User user = 1;
 }
 
 // GetUserAdminRequest represents a request to query a user by admin
@@ -205,6 +185,68 @@ message LookUpUserAdminRequest {
 message LookUpUserAdminResponse {
   // A user resource
   User user = 1;
+}
+
+// ListOrganizationsAdminRequest represents a request to list all organizations by admin
+message ListOrganizationsAdminRequest {
+  // Page size: the maximum number of resources to return. The service may
+  // return fewer than this value. If unspecified, at most 10 organizations will be
+  // returned. The maximum value is 100; values above 100 will be coereced to
+  // 100.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list organizations
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListOrganizationsAdminResponse represents a response for a list of organizations
+message ListOrganizationsAdminResponse {
+  // A list of organizations
+  repeated Organization organizations = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of organizations
+  int32 total_size = 3;
+}
+
+// GetOrganizationAdminRequest represents a request to query a organization by admin
+message GetOrganizationAdminRequest {
+  // Resource name of a organization. For example:
+  // "organizations/local-organization"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Organization",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization.name"}
+    }
+  ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationAdminResponse represents a response for a organization resource
+message GetOrganizationAdminResponse {
+  // A organization resource
+  Organization organization = 1;
+}
+
+// LookUpOrganizationAdminRequest represents a request to query a organization via permalink by
+// admin
+message LookUpOrganizationAdminRequest {
+  // Permalink of a organization. For example:
+  // "organizations/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpOrganizationAdminResponse represents a response for a organization resource by admin
+message LookUpOrganizationAdminResponse {
+  // A organization resource
+  Organization organization = 1;
 }
 
 // ListUsersRequest represents a request to list all users
@@ -269,25 +311,36 @@ message PatchAuthenticatedUserResponse {
   User user = 1;
 }
 
-// ExistUsernameRequest represents a request to verify if
-// a username has been occupied
-message ExistUsernameRequest {
-  // The resource name of the user to check,
-  // for example: "users/local-user"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
-    }
-  ];
+// CheckNamespaceRequest represents a request to verify if
+// a namespace has been occupied and know its type
+message CheckNamespaceRequest {
+  // CheckNamespaceRequestBody
+  message CheckNamespaceRequestBody {
+    // The resource id of to check,
+    string id = 1 [(google.api.field_behavior) = REQUIRED];
+  }
+  // body
+  CheckNamespaceRequestBody namespace = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-// ExistUsernameResponse represents a response about whether
+// CheckNamespaceResponse represents a response about whether
 // the queried username has been occupied
-message ExistUsernameResponse {
+message CheckNamespaceResponse {
+  // Namespace type
+  enum Namespace {
+    // UNSPECIFIED
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available
+    NAMESPACE_AVAILABLE = 1;
+    // User
+    NAMESPACE_USER = 2;
+    // Org
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved
+    NAMESPACE_RESERVED = 4;
+  }
   // A boolean value indicating whether the username has been occupied
-  bool exists = 1;
+  Namespace type = 1;
 }
 
 // ApiToken represents the content of a API token
@@ -495,9 +548,8 @@ message Organization {
   // Resource name. It must have the format of "organizations/*".
   // For example: "organizations/local-organization".
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Organization ID in UUIDv4. This field is optionally set by organizations
-  // (optional on resource creation, server-generated if unset).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
+  // Organization ID in UUIDv4.
+  string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Resource ID (the last segment of the resource name), also the organization
   // name. This conforms to RFC-1034, which restricts to letters, numbers,
   // and hyphen, with the first character a letter, the last a letter or a
@@ -510,6 +562,12 @@ message Organization {
   google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Organization company or institution name
   optional string org_name = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Stripe customer ID. This field is used in Instill Cloud.
+  string customer_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Profile Avatar base64
+  optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Data
+  optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations
@@ -627,118 +685,40 @@ message ExistOrganizationNameResponse {
   bool exists = 1;
 }
 
-// OrganizationInvitation represents the content of a organization invitation
-message OrganizationInvitation {
-  option (google.api.resource) = {
-    type: "api.instill.tech/OrganizationInvitation"
-    pattern: "organizations/{organization}/invitations/{invitation}"
-  };
-
-  // Resource name. It must have the format of "organizations/*/invitations/*".
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Organization ID in UUIDv4. This field is optionally set by organizations
-  // (optional on resource creation, server-generated if unset).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
-  // Resource ID (the last segment of the resource name), also the organization
-  // name. This conforms to RFC-1034, which restricts to letters, numbers,
-  // and hyphen, with the first character a letter, the last a letter or a
-  // number, and a 63 character maximum.
-
-  // User
-  oneof user {
-    // User ID
-    string user_id = 3 [(google.api.field_behavior) = REQUIRED];
-    // User Email
-    string user_email = 4 [(google.api.field_behavior) = REQUIRED];
-  }
-
-  // Role
-  string role = 5 [(google.api.field_behavior) = REQUIRED];
-
-  // Invitor
-  User invitor = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  //InvitationState
-  InvitationState state = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // create time
-  google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // update time
-  google.protobuf.Timestamp update_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // Membership represents the content of a membership
 message OrganizationMembership {
-  // Resource name. It must have the format of "organizations/*/memberships/*" or "users/*/memberships/*".
+  // Resource name. It must have the format of "organizations/*/memberships/*"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Organization ID in UUIDv4. This field is optionally set by organizations
-  // (optional on resource creation, server-generated if unset).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
-  // Resource ID (the last segment of the resource name), also the organization
-  // name. This conforms to RFC-1034, which restricts to letters, numbers,
-  // and hyphen, with the first character a letter, the last a letter or a
-  // number, and a 63 character maximum.
 
   // Role
   string role = 3 [(google.api.field_behavior) = REQUIRED];
 
   // State
-  MembershipState state = 4;
+  MembershipState state = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // User
   User user = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Organization
-  User organization = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // create time
-  google.protobuf.Timestamp create_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // update time
-  google.protobuf.Timestamp update_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  Organization organization = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Membership represents the content of a membership
 message UserMembership {
-  // Resource name. It must have the format of "organizations/*/memberships/*" or "users/*/memberships/*".
+  // Resource name. It must have the format of "users/*/memberships/*".
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Organization ID in UUIDv4. This field is optionally set by organizations
-  // (optional on resource creation, server-generated if unset).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
-  // Resource ID (the last segment of the resource name), also the organization
-  // name. This conforms to RFC-1034, which restricts to letters, numbers,
-  // and hyphen, with the first character a letter, the last a letter or a
-  // number, and a 63 character maximum.
-
   // Role
-  string role = 3 [(google.api.field_behavior) = REQUIRED];
-
+  string role = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // State
-  MembershipState state = 4;
-
+  MembershipState state = 4 [(google.api.field_behavior) = REQUIRED];
   // User
   User user = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-
   // Organization
-  User organization = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // create time
-  google.protobuf.Timestamp create_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // update time
-  google.protobuf.Timestamp update_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  Organization organization = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListUserMembershipsRequest represents a request to list user memberships
 message ListUserMembershipsRequest {
-  // The maximum number of organizations to return. The service may return fewer
-  // than this value. If unspecified, at most 10 organizations will be returned. The
-  // maximum value is 100; values above 100 will be coerced to 100.
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list organizations
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource where this connector resource will be created.
   // Format: users/{users}
   string parent = 5 [
@@ -751,10 +731,6 @@ message ListUserMembershipsRequest {
 message ListUserMembershipsResponse {
   // A list of memberships
   repeated UserMembership memberships = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of membership resources
-  int32 total_size = 3;
 }
 
 // GetUserMembershipRequest represents a request to query a membership
@@ -808,16 +784,6 @@ message DeleteUserMembershipResponse {}
 
 // ListOrganizationMembershipsRequest represents a request to list organization memberships
 message ListOrganizationMembershipsRequest {
-  // The maximum number of organizations to return. The service may return fewer
-  // than this value. If unspecified, at most 10 organizations will be returned. The
-  // maximum value is 100; values above 100 will be coerced to 100.
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list organizations
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource where this connector resource will be created.
   // Format: organization/{organizations}
   string parent = 5 [
@@ -830,10 +796,6 @@ message ListOrganizationMembershipsRequest {
 message ListOrganizationMembershipsResponse {
   // A list of memberships
   repeated OrganizationMembership memberships = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of membership resources
-  int32 total_size = 3;
 }
 
 // GetOrganizationMembershipRequest represents a request to query a membership
@@ -884,86 +846,3 @@ message DeleteOrganizationMembershipRequest {
 
 // DeleteOrganizationMembershipResponse represents an empty response
 message DeleteOrganizationMembershipResponse {}
-
-// ListOrganizationInvitationsRequest represents a request to list organization invitations
-message ListOrganizationInvitationsRequest {
-  // The maximum number of organizations to return. The service may return fewer
-  // than this value. If unspecified, at most 10 organizations will be returned. The
-  // maximum value is 100; values above 100 will be coerced to 100.
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list organizations
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
-  // The parent resource where this connector resource will be created.
-  // Format: organization/{organizations}
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"}
-  ];
-}
-
-// ListOrganizationInvitationsResponse represents a response for a list of invitations
-message ListOrganizationInvitationsResponse {
-  // A list of invitations
-  repeated OrganizationInvitation invitations = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of invitation resources
-  int32 total_size = 3;
-}
-
-// CreateOrganizationInvitationRequest represents a request to create a pipeline
-message CreateOrganizationInvitationRequest {
-  // A pipeline resource to create
-  OrganizationInvitation invitation = 1 [(google.api.field_behavior) = REQUIRED];
-  // The parent resource where this connector resource will be created.
-  // Format: users/{users}
-  string parent = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/OrganizationInvitation"}
-  ];
-}
-
-// CreateOrganizationInvitationResponse represents a response for a pipeline resource
-message CreateOrganizationInvitationResponse {
-  // The created pipeline resource
-  OrganizationInvitation invitation = 1;
-}
-
-// GetOrganizationInvitationRequest represents a request to query a invitation
-message GetOrganizationInvitationRequest {
-  // Invitation resource name. It must have the format of "organizations/*/invitations/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationInvitation"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "invitation.name"}
-    }
-  ];
-  // Invitation resource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// GetOrganizationInvitationResponse represents a response for a invitation resource
-message GetOrganizationInvitationResponse {
-  // A invitation resource
-  OrganizationInvitation invitation = 1;
-}
-
-// DeleteOrganizationInvitationRequest represents a request to delete a invitation resource
-message DeleteOrganizationInvitationRequest {
-  // Invitation resource name. It must have the format of "organizations/*/invitation/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationInvitation"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "invitation.name"}
-    }
-  ];
-}
-
-// DeleteOrganizationInvitationResponse represents an empty response
-message DeleteOrganizationInvitationResponse {}

--- a/integration-test/proto/core/mgmt/v1alpha/mgmt_private_service.proto
+++ b/integration-test/proto/core/mgmt/v1alpha/mgmt_private_service.proto
@@ -15,16 +15,6 @@ service MgmtPrivateService {
     option (google.api.http) = {get: "/v1alpha/admin/users"};
   }
 
-  // CreateUserAdmin receives a CreateUserAdminRequest message and returns a
-  // a GetUserAdminResponse
-  rpc CreateUserAdmin(CreateUserAdminRequest) returns (CreateUserAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/users"
-      body: "user"
-    };
-    option (google.api.method_signature) = "user";
-  }
-
   // GetUserAdmin method receives a GetUserAdminRequest message and returns
   // a GetUserAdminResponse message.
   rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {
@@ -36,6 +26,26 @@ service MgmtPrivateService {
   // returns a LookUpUserAdminResponse
   rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
     option (google.api.http) = {get: "/v1alpha/admin/{permalink=users/*}/lookUp"};
+    option (google.api.method_signature) = "permalink";
+  }
+
+  // ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
+  // a ListOrganizationsAdminResponse message.
+  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/organizations"};
+  }
+
+  // GetOrganizationAdmin method receives a GetOrganizationAdminRequest message and returns
+  // a GetOrganizationAdminResponse message.
+  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{name=organizations/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
+  // returns a LookUpOrganizationAdminResponse
+  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{permalink=organizations/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 }

--- a/integration-test/proto/core/mgmt/v1alpha/mgmt_public_service.proto
+++ b/integration-test/proto/core/mgmt/v1alpha/mgmt_public_service.proto
@@ -34,6 +34,15 @@ service MgmtPublicService {
     };
   }
 
+  // Check namespace
+  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/check-namespace"
+      body: "namespace"
+    };
+    option (google.api.method_signature) = "namespace";
+  }
+
   // ListUsers method receives a ListUsersRequest message and returns a
   // ListUsersResponse message.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
@@ -57,13 +66,6 @@ service MgmtPublicService {
     option (google.api.method_signature) = "user,update_mask";
   }
 
-  // ExistUsername method receives a ExistUsernameRequest message and returns a
-  // ExistUsernameResponse
-  rpc ExistUsername(ExistUsernameRequest) returns (ExistUsernameResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=users/*}/exist"};
-    option (google.api.method_signature) = "name";
-  }
-
   // ListUserMemberships method receives a ListUserMembershipsRequest message and returns a
   // ListUserMembershipsResponse message.
   rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
@@ -82,7 +84,7 @@ service MgmtPublicService {
   // a UpdateUserMembershipResponse message.
   rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{membership.name=users/*/memberships/*}"
+      put: "/v1alpha/{membership.name=users/*/memberships/*}"
       body: "membership"
     };
     option (google.api.method_signature) = "membership,update_mask";
@@ -153,7 +155,7 @@ service MgmtPublicService {
   // a UpdateOrganizationMembershipResponse message.
   rpc UpdateOrganizationMembership(UpdateOrganizationMembershipRequest) returns (UpdateOrganizationMembershipResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{membership.name=organizations/*/memberships/*}"
+      put: "/v1alpha/{membership.name=organizations/*/memberships/*}"
       body: "membership"
     };
     option (google.api.method_signature) = "membership,update_mask";
@@ -163,37 +165,6 @@ service MgmtPublicService {
   // a DeleteOrganizationMembershipResponse message.
   rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // ListOrganizationInvitations method receives a ListOrganizationInvitationsRequest message and returns a
-  // ListOrganizationInvitationpsResponse message.
-  rpc ListOrganizationInvitations(ListOrganizationInvitationsRequest) returns (ListOrganizationInvitationsResponse) {
-    option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/invitations"};
-    option (google.api.method_signature) = "parent";
-  }
-
-  // CreateOrganizationInvitation method receives a CreateOrganizationInvitationRequest message and returns
-  // a CreateOrganizationInvitationResponse message.
-  rpc CreateOrganizationInvitation(CreateOrganizationInvitationRequest) returns (CreateOrganizationInvitationResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{parent=organizations/*}/invitations"
-      body: "invitation"
-    };
-    option (google.api.method_signature) = "parent,invitation";
-  }
-
-  // GetOrganizationInvitation method receives a GetOrganizationInvitationRequest message and returns a
-  // GetOrganizationInvitationResponse message.
-  rpc GetOrganizationInvitation(GetOrganizationInvitationRequest) returns (GetOrganizationInvitationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/invitations/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // DeleteOrganizationInvitation method receives a DeleteOrganizationInvitationRequest message and returns
-  // a DeleteOrganizationInvitationResponse message.
-  rpc DeleteOrganizationInvitation(DeleteOrganizationInvitationRequest) returns (DeleteOrganizationInvitationResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/invitations/*}"};
     option (google.api.method_signature) = "name";
   }
 


### PR DESCRIPTION
Because

- we need an API to determine the availability of a namespace id and its type

This commit

- remove ExistUsername API  and add new CheckNamespace API
