### PR TITLE
chore(deps): adopt latest Core protobufs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe h1:8x6a2zzX858AgXd5Cuq+/xkf3kYmcgHbOkzgg1K61VU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206042803-5ace80a1eafe/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72 h1:uu5P8Bjr2T6XUV7PPzl7InpHYN6P+xcbkOrgZN7WdWE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97 h1:WycXqzJP1ihjJwrkxlNP2TQc1DSUxUtfl/PtCpLBa3Y=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97/go.mod h1:Da8RdKakfxy1iNdvI5FSTcL1lSDtda+b9jOgOEEO68E=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -329,18 +329,18 @@ func (h *PublicHandler) CheckNamespace(ctx context.Context, req *mgmtPB.CheckNam
 		trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
-	err := checkfield.CheckResourceID(req.GetNamespace().GetId())
+	err := checkfield.CheckResourceID(req.GetId())
 	if err != nil {
 		return nil, ErrResourceID
 	}
 
-	_, err = h.Service.GetUserAdmin(ctx, req.GetNamespace().GetId())
+	_, err = h.Service.GetUserAdmin(ctx, req.GetId())
 	if err == nil {
 		return &mgmtPB.CheckNamespaceResponse{
 			Type: mgmtPB.CheckNamespaceResponse_NAMESPACE_USER,
 		}, nil
 	}
-	_, err = h.Service.GetOrganizationAdmin(ctx, req.GetNamespace().GetId())
+	_, err = h.Service.GetOrganizationAdmin(ctx, req.GetId())
 	if err == nil {
 		return &mgmtPB.CheckNamespaceResponse{
 			Type: mgmtPB.CheckNamespaceResponse_NAMESPACE_ORGANIZATION,


### PR DESCRIPTION
Because

- we simplified the message of CheckNamespace endpoint

This commit

- adopt latest Core protobufs
