### PR TITLE
chore(handler): fix update mask error

### DIFF
--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -513,6 +513,12 @@ func (h *PublicHandler) UpdateOrganization(ctx context.Context, req *mgmtPB.Upda
 
 	pbOrgReq := req.GetOrganization()
 	pbUpdateMask := req.GetUpdateMask()
+	// profile_data field is type google.protobuf.Struct, which needs to be updated as a whole
+	for idx, path := range pbUpdateMask.Paths {
+		if strings.Contains(path, "profile_data") {
+			pbUpdateMask.Paths[idx] = "profile_data"
+		}
+	}
 
 	// Validate the field mask
 	if !pbUpdateMask.IsValid(pbOrgReq) {


### PR DESCRIPTION
Because

- there is a bug update mask for `profile_data`

This commit

- fix update mask error
