### PR TITLE
fix(handler): fix organization can not revoke user membership

### DIFF
--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -1580,7 +1580,7 @@ func (h *PublicHandler) DeleteOrganizationMembership(ctx context.Context, req *m
 	orgID := strings.Split(req.Name, "/")[1]
 	userID := strings.Split(req.Name, "/")[3]
 
-	err = h.Service.DeleteUserMembership(ctx, ctxUserUID, userID, orgID)
+	err = h.Service.DeleteOrganizationMembership(ctx, ctxUserUID, orgID, userID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err


### PR DESCRIPTION
Because

- organization should be abled to revoke user membership

This commit

- fix organization can not revoke user membership
