### PR TITLE
chore(service): add owner field in organization payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231208161503-706306fd242e
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1105,8 +1105,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72 h1:uu5P8Bjr2T6XUV7PPzl7InpHYN6P+xcbkOrgZN7WdWE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206145634-e01af3dc7f72/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231208161503-706306fd242e h1:dnZvLQnuUqpAozwj59sQRpeTF4tg+qeIkLvHKuMc788=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231208161503-706306fd242e/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97 h1:WycXqzJP1ihjJwrkxlNP2TQc1DSUxUtfl/PtCpLBa3Y=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97/go.mod h1:Da8RdKakfxy1iNdvI5FSTcL1lSDtda+b9jOgOEEO68E=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -162,6 +162,22 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 	id := dbOrg.ID
 	uid := dbOrg.Base.UID.String()
 
+	relations, err := s.aclClient.GetOrganizationUsers(dbOrg.Base.UID)
+	if err != nil {
+		return nil, err
+	}
+
+	var owner *mgmtPB.User
+	for _, relation := range relations {
+		if relation.Relation == "owner" {
+			owner, err = s.GetUserByUIDAdmin(ctx, relation.UID)
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+
 	return &mgmtPB.Organization{
 		Name:          fmt.Sprintf("organizations/%s", id),
 		Uid:           uid,
@@ -179,6 +195,7 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 			}
 			return str
 		}(),
+		Owner: owner,
 	}, nil
 }
 


### PR DESCRIPTION
Because

- we need to embed owner information in the organization payload

This commit

- add owner field in organization payload
