### PR TITLE
feat: implement cache mechanism

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -32,13 +32,13 @@ const randomUUID = uuidv4();
 export const restParamsWithJwtSub = {
   headers: {
     "Content-Type": "application/json",
-    "Jwt-Sub": randomUUID,
+    "instill-user-uid": randomUUID,
   },
 }
 
 export const grpcParamsWithJwtSub = {
   metadata: {
-    "Jwt-Sub": randomUUID,
+    "instill-user-uid": randomUUID,
   },
 }
 

--- a/integration-test/grpc-public-user-with-jwt.js
+++ b/integration-test/grpc-public-user-with-jwt.js
@@ -15,14 +15,14 @@ client.load(['proto/core/mgmt/v1beta'], 'mgmt_public_service.proto');
 
 export function CheckPublicGetUser() {
 
-  group(`Management Public API: Get authenticated user [with random "jwt-sub" header]`, () => {
+  group(`Management Public API: Get authenticated user [with random "instill-user-uid" header]`, () => {
 
     client.connect(constant.mgmtPublicGRPCHost, {
       plaintext: true
     });
 
     check(client.invoke('core.mgmt.v1beta.MgmtPublicService/GetUser', {name: "users/me"}, constant.grpcParamsWithJwtSub), {
-      '[with random "jwt-sub" header] core.mgmt.v1beta.MgmtPublicService/GetUser status StatusUnauthenticated': (r) => r && r.status == grpc.StatusUnauthenticated,
+      '[with random "instill-user-uid" header] core.mgmt.v1beta.MgmtPublicService/GetUser status StatusUnauthenticated': (r) => r && r.status == grpc.StatusUnauthenticated,
     });
 
     client.close();
@@ -35,7 +35,7 @@ export function CheckPublicPatchAuthenticatedUser() {
     plaintext: true
   });
 
-  group(`Management Public API: Update authenticated user [with random "jwt-sub" header]`, () => {
+  group(`Management Public API: Update authenticated user [with random "instill-user-uid" header]`, () => {
     var userUpdate = {
       name: `users/${constant.defaultUser.id}`,
       email: "test@foo.bar",
@@ -52,7 +52,7 @@ export function CheckPublicPatchAuthenticatedUser() {
       user: userUpdate,
       update_mask: "email,firstName,lastName,orgName,role,newsletterSubscription,cookieToken"
     }, constant.grpcParamsWithJwtSub), {
-      '[with random "jwt-sub" header] core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser status StatusUnauthenticated': (r) => r && r.status == grpc.StatusUnauthenticated,
+      '[with random "instill-user-uid" header] core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser status StatusUnauthenticated': (r) => r && r.status == grpc.StatusUnauthenticated,
     });
   });
 

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -45,7 +45,7 @@ export default function (header) {
     mgmtPrivate.CheckPrivateLookUpUserAdmin();
 
   } else {
-    // ======== Public API with jwt-sub
+    // ======== Public API with instill-user-uid
     mgmtPublicWithJwt.CheckPublicGetUser();
     mgmtPublicWithJwt.CheckPublicPatchAuthenticatedUser();
     // ======== Public API

--- a/integration-test/rest-public-user-with-jwt.js
+++ b/integration-test/rest-public-user-with-jwt.js
@@ -6,11 +6,11 @@ import * as helper from "./helper.js";
 
 
 export function CheckPublicGetUser() {
-  group(`Management Public API: Get authenticated user [with random "jwt-sub" header]`, () => {
+  group(`Management Public API: Get authenticated user [with random "instill-user-uid" header]`, () => {
 
     check(http.request("GET", `${constant.mgmtPublicHost}/users/me`, {}, constant.restParamsWithJwtSub),
       {
-        [`[with random "jwt-sub" header] GET /${constant.mgmtVersion}/users/me response status 401`]:
+        [`[with random "instill-user-uid" header] GET /${constant.mgmtVersion}/users/me response status 401`]:
           (r) => r.status === 401,
       }
     )
@@ -18,7 +18,7 @@ export function CheckPublicGetUser() {
 }
 
 export function CheckPublicPatchAuthenticatedUser() {
-  group(`Management Public API: Update authenticated user [with random "jwt-sub" header]`, () => {
+  group(`Management Public API: Update authenticated user [with random "instill-user-uid" header]`, () => {
     var userUpdate = {
       email: "test@foo.bar",
       customer_id: "new_customer_id",
@@ -34,7 +34,7 @@ export function CheckPublicPatchAuthenticatedUser() {
 
     check(http.request("PATCH", `${constant.mgmtPublicHost}/users/me`, JSON.stringify(userUpdate), constant.restParamsWithJwtSub),
       {
-        [`[with random "jwt-sub" header] PATCH /${constant.mgmtVersion}/users/me response status 401`]: (r) => r.status === 401,
+        [`[with random "instill-user-uid" header] PATCH /${constant.mgmtVersion}/users/me response status 401`]: (r) => r.status === 401,
       }
     );
   });

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -46,7 +46,7 @@ export default function (header) {
     mgmtPrivate.CheckPrivateLookUpUserAdmin();
 
   } else {
-    // ======== Public API with jwt-sub
+    // ======== Public API with instill-user-uid
     mgmtPublicWithJwt.CheckPublicGetUser();
     mgmtPublicWithJwt.CheckPublicPatchAuthenticatedUser();
     // ======== Public API

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -15,10 +15,13 @@ const DefaultJwtIssuer = "http://localhost:8080"
 const DefaultJwtAudience = "http://localhost:8080"
 
 // HeaderUserIDKey is the header key for the User ID
-const HeaderUserIDKey = "user-id"
+const HeaderUserIDKey = "Instill-User-Id"
 
 // HeaderUserUIDKey is the header key for the User UID
-const HeaderUserUIDKey = "jwt-sub"
+const HeaderUserUIDKey = "Instill-User-Uid"
+const HeaderVisitorUIDKey = "Instill-Visitor-Uid"
+
+const HeaderAuthType = "Instill-Auth-Type"
 
 // MaxApiKeyNum is the maximum number of API keys
 const MaxApiKeyNum = 10

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 )
 
@@ -34,11 +33,12 @@ func CustomMatcher(key string) (string, bool) {
 	if strings.HasPrefix(strings.ToLower(key), "jwt-") {
 		return key, true
 	}
+	if strings.HasPrefix(strings.ToLower(key), "instill-") {
+		return key, true
+	}
 
 	switch key {
 	case "request-id":
-		return key, true
-	case constant.HeaderUserIDKey:
 		return key, true
 	case "X-B3-Traceid", "X-B3-Spanid", "X-B3-Sampled":
 		return key, true

--- a/pkg/service/cache.go
+++ b/pkg/service/cache.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+)
+
+const CacheTargetUser = "user"
+const CacheTargetOrganization = "organization"
+const CacheTargetUserPasswordHash = "user_password_hash"
+
+func (s *service) getFromCacheByID(ctx context.Context, target string, id string) interface{} {
+	getCmd := s.redisClient.Get(ctx, fmt.Sprintf("%s:%s", target, id))
+	if getCmd.Err() == nil {
+		b, err := getCmd.Bytes()
+		if err == nil {
+			if target == CacheTargetUser {
+				pbUser := &mgmtPB.User{}
+				if err := protojson.Unmarshal(b, pbUser); err == nil {
+					return pbUser
+				}
+			} else {
+				pbOrg := &mgmtPB.Organization{}
+				if err := protojson.Unmarshal(b, pbOrg); err == nil {
+					return pbOrg
+				}
+			}
+		}
+	}
+	return nil
+}
+func (s *service) getFromCacheByUID(ctx context.Context, target string, uid uuid.UUID) interface{} {
+	return s.getFromCacheByID(ctx, target, uid.String())
+}
+func (s *service) getUserFromCacheByID(ctx context.Context, id string) *mgmtPB.User {
+	i := s.getFromCacheByID(ctx, CacheTargetUser, id)
+	if i != nil {
+		return i.(*mgmtPB.User)
+	} else {
+		return nil
+	}
+}
+func (s *service) getOrganizationFromCacheByID(ctx context.Context, id string) *mgmtPB.Organization {
+	i := s.getFromCacheByID(ctx, CacheTargetOrganization, id)
+	if i != nil {
+		return i.(*mgmtPB.Organization)
+	} else {
+		return nil
+	}
+}
+func (s *service) getUserFromCacheByUID(ctx context.Context, uid uuid.UUID) *mgmtPB.User {
+	i := s.getFromCacheByUID(ctx, CacheTargetUser, uid)
+	if i != nil {
+		return i.(*mgmtPB.User)
+	} else {
+		return nil
+	}
+}
+func (s *service) getOrganizationFromCacheByUID(ctx context.Context, uid uuid.UUID) *mgmtPB.Organization {
+	i := s.getFromCacheByUID(ctx, CacheTargetOrganization, uid)
+	if i != nil {
+		return i.(*mgmtPB.Organization)
+	} else {
+		return nil
+	}
+}
+
+func (s *service) setToCache(ctx context.Context, target string, src interface{}) error {
+	var b []byte
+	var id string
+	var uid string
+	var err error
+
+	switch src := src.(type) {
+	case *mgmtPB.User:
+		b, err = protojson.Marshal(src)
+		if err != nil {
+			return err
+		}
+		id = src.Id
+		uid = *src.Uid
+	case *mgmtPB.Organization:
+		b, err = protojson.Marshal(src)
+		if err != nil {
+			return err
+		}
+		id = src.Id
+		uid = src.Uid
+	}
+
+	setCmd := s.redisClient.Set(ctx, fmt.Sprintf("%s:%s", target, id), b, 0)
+	if setCmd.Err() != nil {
+		return setCmd.Err()
+	}
+	setCmd = s.redisClient.Set(ctx, fmt.Sprintf("%s:%s", target, uid), b, 0)
+	if setCmd.Err() != nil {
+		return setCmd.Err()
+	}
+	return nil
+}
+func (s *service) setUserToCache(ctx context.Context, user *mgmtPB.User) error {
+	return s.setToCache(ctx, CacheTargetUser, user)
+}
+func (s *service) setOrganizationToCache(ctx context.Context, org *mgmtPB.Organization) error {
+	return s.setToCache(ctx, CacheTargetOrganization, org)
+}
+
+func (s *service) deleteFromCacheByID(ctx context.Context, target string, id string) error {
+
+	var uid string
+	if target == CacheTargetUser {
+		user := s.getFromCacheByID(ctx, target, id)
+		if user != nil {
+			uid = *user.(*mgmtPB.User).Uid
+		}
+
+	} else {
+
+		org := s.getFromCacheByID(ctx, target, id)
+		if org != nil {
+			uid = org.(*mgmtPB.Organization).Uid
+		}
+	}
+
+	setCmd := s.redisClient.Del(ctx, fmt.Sprintf("%s:%s", target, id))
+	if setCmd.Err() != nil {
+		return setCmd.Err()
+	}
+	if uid != "" {
+		setCmd = s.redisClient.Del(ctx, fmt.Sprintf("%s:%s", target, uid))
+		if setCmd.Err() != nil {
+			return setCmd.Err()
+		}
+	}
+
+	return nil
+}
+
+func (s *service) deleteUserFromCacheByID(ctx context.Context, id string) error {
+	return s.deleteFromCacheByID(ctx, CacheTargetUser, id)
+}
+func (s *service) deleteOrganizationFromCacheByID(ctx context.Context, id string) error {
+	return s.deleteFromCacheByID(ctx, CacheTargetOrganization, id)
+}
+
+func (s *service) getUserPasswordHashFromCache(ctx context.Context, uid uuid.UUID) string {
+	getCmd := s.redisClient.Get(ctx, fmt.Sprintf("%s:%s", CacheTargetUserPasswordHash, uid))
+	if getCmd.Err() == nil {
+		return getCmd.Val()
+	}
+	return ""
+}
+
+func (s *service) setUserPasswordHashToCache(ctx context.Context, uid uuid.UUID, hash string) error {
+
+	setCmd := s.redisClient.Set(ctx, fmt.Sprintf("%s:%s", CacheTargetUserPasswordHash, uid), hash, 0)
+	if setCmd.Err() != nil {
+		return setCmd.Err()
+	}
+
+	return nil
+}
+
+func (s *service) deleteUserPasswordHashFromCache(ctx context.Context, uid uuid.UUID) error {
+
+	setCmd := s.redisClient.Del(ctx, fmt.Sprintf("%s:%s", CacheTargetUserPasswordHash, uid))
+	if setCmd.Err() != nil {
+		return setCmd.Err()
+	}
+
+	return nil
+}

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -18,7 +18,7 @@ import (
 )
 
 func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", owner.GetUid())
+	ctx = metadata.AppendToOutgoingContext(ctx, "instill-user-uid", owner.GetUid())
 	return ctx
 }
 


### PR DESCRIPTION
Because

- User and organization data fall into the category of data that is more frequently read than written. Implementing a cache mechanism can enhance performance.

This commit

- Implement cache mechanism for user and organization data with write-through and lazy-loading approach
