### PR TITLE
refactor: pass `defaultUserID` into `usage` struct

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -194,7 +194,7 @@ func main() {
 			logger.Info("try to start usage reporter")
 			go func() {
 				for {
-					usg = usage.NewUsage(ctx, service, usageServiceClient, config.Config.Server.Edition)
+					usg = usage.NewUsage(ctx, service, usageServiceClient, config.Config.Server.Edition, constant.DefaultUserID)
 					if usg != nil {
 						usg.StartReporter(ctx)
 						logger.Info("usage reporter started")


### PR DESCRIPTION
Because

- we don't want to use constant directly in `usage` struct

This commit

- pass `defaultUserID` into `usage` struct
