### PR TITLE
refactor: update variable name with initialisms

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54
+          args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+linters:
+  enable:
+    - stylecheck
+
+linters-settings:
+  stylecheck:
+    checks: [ "all" ]

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -39,8 +39,8 @@ func createDefaultUser(ctx context.Context, db *gorm.DB) error {
 	// Generate a random uid to the user
 	var defaultUserUID uuid.UUID
 	var err error
-	if config.Config.Server.DefaultUserUid != "" {
-		defaultUserUID, err = uuid.FromString(config.Config.Server.DefaultUserUid)
+	if config.Config.Server.DefaultUserUID != "" {
+		defaultUserUID, err = uuid.FromString(config.Config.Server.DefaultUserUID)
 	} else {
 		defaultUserUID, err = uuid.NewV4()
 	}
@@ -60,7 +60,7 @@ func createDefaultUser(ctx context.Context, db *gorm.DB) error {
 		ID:                     constant.DefaultUserID,
 		OwnerType:              sql.NullString{String: service.PBUserType2DBUserType[mgmtPB.OwnerType_OWNER_TYPE_USER], Valid: true},
 		Email:                  constant.DefaultUserEmail,
-		CustomerId:             constant.DefaultUserCustomerId,
+		CustomerID:             constant.DefaultUserCustomerID,
 		FirstName:              sql.NullString{String: constant.DefaultUserFirstName, Valid: true},
 		LastName:               sql.NullString{String: constant.DefaultUserLastName, Valid: true},
 		OrgName:                sql.NullString{String: constant.DefaultUserOrgName, Valid: true},
@@ -153,18 +153,18 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	storeId := ""
+	storeID := ""
 	if len(*stores.Stores) == 0 {
 		data, err := fgaClient.CreateStore(context.Background()).Body(openfga.ClientCreateStoreRequest{Name: "instill"}).Execute()
 		if err != nil {
 			panic(err)
 		}
-		storeId = *data.Id
+		storeID = *data.Id
 	} else {
-		storeId = *(*stores.Stores)[0].Id
+		storeID = *(*stores.Stores)[0].Id
 	}
 
-	fgaClient.SetStoreId(storeId)
+	fgaClient.SetStoreId(storeID)
 
 	models, err := fgaClient.ReadAuthorizationModels(context.Background()).Execute()
 	if err != nil {

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -223,7 +223,7 @@ func main() {
 	)
 
 	privateServeMux := runtime.NewServeMux(
-		runtime.WithForwardResponseOption(middleware.HttpResponseModifier),
+		runtime.WithForwardResponseOption(middleware.HTTPResponseModifier),
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithErrorHandler(middleware.ErrorHandler),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
@@ -240,7 +240,7 @@ func main() {
 
 	publicServeMux := runtime.NewServeMux(
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
-		runtime.WithForwardResponseOption(middleware.HttpResponseModifier),
+		runtime.WithForwardResponseOption(middleware.HTTPResponseModifier),
 		runtime.WithErrorHandler(middleware.ErrorHandler),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type ServerConfig struct {
 		Port       int    `koanf:"port"`
 	}
 	Debug          bool   `koanf:"debug"`
-	DefaultUserUid string `koanf:"defaultuseruid"`
+	DefaultUserUID string `koanf:"defaultuseruid"`
 }
 
 // TemporalConfig related to Temporal

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -47,8 +47,8 @@ func GetRscPermalinkUID(path string) (uuid.UUID, error) {
 	return uuid.FromStringOrNil(splits[1]), nil
 }
 
-func UserUidToUserPermalink(userUid uuid.UUID) string {
-	return fmt.Sprintf("users/%s", userUid.String())
+func UserUIDToUserPermalink(userUID uuid.UUID) string {
+	return fmt.Sprintf("users/%s", userUID.String())
 }
 
 func ConvertConnectorToResourceName(connectorName string) string {

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -12,7 +12,7 @@ import (
 
 type ACLClient struct {
 	client               *openfgaClient.OpenFgaClient
-	authorizationModelId *string
+	authorizationModelID *string
 }
 
 type Relation struct {
@@ -23,14 +23,14 @@ type Relation struct {
 func NewACLClient(c *openfgaClient.OpenFgaClient, a *string) ACLClient {
 	return ACLClient{
 		client:               c,
-		authorizationModelId: a,
+		authorizationModelID: a,
 	}
 }
 
 func (c *ACLClient) SetOrganizationUserMembership(orgUID uuid.UUID, userUID uuid.UUID, role string) error {
 	var err error
 	options := openfgaClient.ClientWriteOptions{
-		AuthorizationModelId: c.authorizationModelId,
+		AuthorizationModelId: c.authorizationModelID,
 	}
 
 	_ = c.DeleteOrganizationUserMembership(orgUID, userUID)
@@ -54,7 +54,7 @@ func (c *ACLClient) SetOrganizationUserMembership(orgUID uuid.UUID, userUID uuid
 func (c *ACLClient) DeleteOrganizationUserMembership(orgUID uuid.UUID, userUID uuid.UUID) error {
 	// var err error
 	options := openfgaClient.ClientWriteOptions{
-		AuthorizationModelId: c.authorizationModelId,
+		AuthorizationModelId: c.authorizationModelID,
 	}
 
 	for _, role := range []string{"owner", "member", "pending_owner", "pending_member"} {
@@ -74,7 +74,7 @@ func (c *ACLClient) DeleteOrganizationUserMembership(orgUID uuid.UUID, userUID u
 
 func (c *ACLClient) CheckOrganizationUserMembership(orgUID uuid.UUID, userUID uuid.UUID, role string) (bool, error) {
 	options := openfgaClient.ClientCheckOptions{
-		AuthorizationModelId: c.authorizationModelId,
+		AuthorizationModelId: c.authorizationModelID,
 	}
 	body := openfgaClient.ClientCheckRequest{
 		User:     fmt.Sprintf("user:%s", userUID.String()),
@@ -175,7 +175,7 @@ func (c *ACLClient) GetUserOrganizations(userUID uuid.UUID) ([]*Relation, error)
 func (c *ACLClient) CheckPermission(objectType string, objectUID uuid.UUID, userType string, userUID uuid.UUID, code string, role string) (bool, error) {
 
 	options := openfgaClient.ClientCheckOptions{
-		AuthorizationModelId: c.authorizationModelId,
+		AuthorizationModelId: c.authorizationModelID,
 	}
 	body := openfgaClient.ClientCheckRequest{
 		User:     fmt.Sprintf("%s:%s", userType, userUID.String()),

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -4,7 +4,7 @@ package constant
 const DefaultUserID = "admin"
 const DefaultUserPassword = "password"
 const DefaultUserEmail = "hello@instill.tech"
-const DefaultUserCustomerId = ""
+const DefaultUserCustomerID = ""
 const DefaultUserOrgName = "Instill AI"
 const DefaultUserFirstName = "Instill"
 const DefaultUserLastName = "AI"
@@ -22,9 +22,6 @@ const HeaderUserUIDKey = "Instill-User-Uid"
 const HeaderVisitorUIDKey = "Instill-Visitor-Uid"
 
 const HeaderAuthType = "Instill-Auth-Type"
-
-// MaxApiKeyNum is the maximum number of API keys
-const MaxApiKeyNum = 10
 
 const DefaultTokenType = "Bearer"
 const AccessTokenKeyFormat = "access_token:%s:owner_permalink"

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -16,11 +16,11 @@ type TokenState int32
 
 const (
 	// State: UNSPECIFIED
-	STATE_UNSPECIFIED TokenState = 0
+	StateUnspecified TokenState = 0
 	// State: INACTIVE
-	STATE_INACTIVE TokenState = 1
+	StateInactive TokenState = 1
 	// State: ACTIVE
-	STATE_ACTIVE TokenState = 2
+	StateActive TokenState = 2
 
 	// In db, we should use current_time < expire_tiem to determine expire or not
 	// We'll convert current_time > expire_tiem to pb's STATE_EXPIRED
@@ -43,7 +43,7 @@ type Owner struct {
 	ID                     string `gorm:"unique;not null;"`
 	OwnerType              sql.NullString
 	Email                  string `gorm:"unique;not null;"`
-	CustomerId             string
+	CustomerID             string
 	FirstName              sql.NullString
 	LastName               sql.NullString
 	OrgName                sql.NullString

--- a/pkg/logger/otel/const.go
+++ b/pkg/logger/otel/const.go
@@ -12,11 +12,11 @@ import (
 type Option func(l logMessage) logMessage
 
 type logMessage struct {
-	Id          string `json:"id"`
+	ID          string `json:"id"`
 	ServiceName string `json:"serviceName"`
 	TraceInfo   struct {
-		TraceId string `json:"traceID"`
-		SpanId  string `json:"spanID"`
+		TraceID string `json:"traceID"`
+		SpanID  string `json:"spanID"`
 	}
 	UserInfo struct {
 		UserID   string `json:"userID"`
@@ -74,25 +74,25 @@ func SetMetadata(m string) Option {
 func NewLogMessage(
 	span trace.Span,
 	logID string,
-	userUid uuid.UUID,
+	userUID uuid.UUID,
 	eventName string,
 	options ...Option,
 ) []byte {
 	logMessage := logMessage{}
-	logMessage.Id = logID
+	logMessage.ID = logID
 	logMessage.ServiceName = "mgmt-backend"
 	logMessage.TraceInfo = struct {
-		TraceId string "json:\"traceID\""
-		SpanId  string "json:\"spanID\""
+		TraceID string "json:\"traceID\""
+		SpanID  string "json:\"spanID\""
 	}{
-		TraceId: span.SpanContext().TraceID().String(),
-		SpanId:  span.SpanContext().SpanID().String(),
+		TraceID: span.SpanContext().TraceID().String(),
+		SpanID:  span.SpanContext().SpanID().String(),
 	}
 	logMessage.UserInfo = struct {
 		UserID   string "json:\"userID\""
 		UserUUID string "json:\"userUUID\""
 	}{
-		UserUUID: userUid.String(),
+		UserUUID: userUID.String(),
 	}
 	logMessage.Event = struct {
 		IsAuditEvent bool "json:\"isAuditEvent\""

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -51,7 +51,7 @@ func CustomMatcher(key string) (string, bool) {
 }
 
 // HTTPResponseModifier is a callback function for gRPC-Gateway runtime.WithForwardResponseOption
-func HttpResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Message) error {
+func HTTPResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Message) error {
 	md, ok := runtime.ServerMetadataFromContext(ctx)
 	if !ok {
 		return nil

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -4,4 +4,4 @@ import "errors"
 
 var ErrPageTokenDecode = errors.New("page token decode error")
 var ErrOwnerTypeNotMatch = errors.New("owner type not match")
-var ErrNoDataDeleted = errors.New("No data deleted")
+var ErrNoDataDeleted = errors.New("no data deleted")

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -93,7 +93,7 @@ func (s *service) DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*
 		CreateTime:             timestamppb.New(dbUser.Base.CreateTime),
 		UpdateTime:             timestamppb.New(dbUser.Base.UpdateTime),
 		Email:                  dbUser.Email,
-		CustomerId:             dbUser.CustomerId,
+		CustomerId:             dbUser.CustomerID,
 		FirstName:              &dbUser.FirstName.String,
 		LastName:               &dbUser.LastName.String,
 		OrgName:                &dbUser.OrgName.String,
@@ -125,7 +125,7 @@ func (s *service) PBUser2DBUser(pbUser *mgmtPB.User) (*datamodel.Owner, error) {
 
 	userType := "user"
 	email := pbUser.GetEmail()
-	customerId := pbUser.GetCustomerId()
+	customerID := pbUser.GetCustomerId()
 	firstName := pbUser.GetFirstName()
 	lastName := pbUser.GetLastName()
 	orgName := pbUser.GetOrgName()
@@ -146,7 +146,7 @@ func (s *service) PBUser2DBUser(pbUser *mgmtPB.User) (*datamodel.Owner, error) {
 			Valid:  len(userType) > 0,
 		},
 		Email:      email,
-		CustomerId: customerId,
+		CustomerID: customerID,
 		FirstName: sql.NullString{
 			String: firstName,
 			Valid:  len(firstName) > 0,
@@ -232,7 +232,7 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 		Id:            id,
 		CreateTime:    timestamppb.New(dbOrg.Base.CreateTime),
 		UpdateTime:    timestamppb.New(dbOrg.Base.UpdateTime),
-		CustomerId:    dbOrg.CustomerId,
+		CustomerId:    dbOrg.CustomerID,
 		OrgName:       &dbOrg.OrgName.String,
 		ProfileAvatar: &dbOrg.ProfileAvatar.String,
 		ProfileData: func() *structpb.Struct {
@@ -259,7 +259,7 @@ func (s *service) PBOrg2DBOrg(pbOrg *mgmtPB.Organization) (*datamodel.Owner, err
 	}
 
 	userType := "organization"
-	customerId := pbOrg.GetCustomerId()
+	customerID := pbOrg.GetCustomerId()
 	orgName := pbOrg.GetOrgName()
 	profileAvatar, err := s.compressAvatar(pbOrg.GetProfileAvatar())
 	if err != nil {
@@ -275,7 +275,7 @@ func (s *service) PBOrg2DBOrg(pbOrg *mgmtPB.Organization) (*datamodel.Owner, err
 			String: userType,
 			Valid:  len(userType) > 0,
 		},
-		CustomerId: customerId,
+		CustomerID: customerID,
 		OrgName: sql.NullString{
 			String: orgName,
 			Valid:  len(orgName) > 0,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -118,9 +118,9 @@ func (s *service) GetACLClient() *acl.ACLClient {
 	return s.aclClient
 }
 
-func (s *service) convertUserIDAlias(ctx context.Context, userUid uuid.UUID, id string) (string, error) {
+func (s *service) convertUserIDAlias(ctx context.Context, userUID uuid.UUID, id string) (string, error) {
 	if id == "me" {
-		user, err := s.GetUserByUIDAdmin(ctx, userUid)
+		user, err := s.GetUserByUIDAdmin(ctx, userUID)
 		if err != nil {
 			return "", ErrUnauthenticated
 		}


### PR DESCRIPTION
Because

- We want to standardize the naming convention on variable name with initialisms

This commit

- Enable stylecheck in golangci-lint
- Update variable name
- Add golangci-lint Github Action
- Remove JSON auto-formatter since it will break the readability