### PR TITLE
fix: the `instill-auth-type` header was missing when request the pipeline

### DIFF
--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -18,6 +18,7 @@ import (
 )
 
 func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, "instill-auth-type", "user")
 	ctx = metadata.AppendToOutgoingContext(ctx, "instill-user-uid", owner.GetUid())
 	return ctx
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.einride.tech/aip/filtering"
 	"golang.org/x/crypto/bcrypt"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/instill-ai/mgmt-backend/internal/resource"
 	"github.com/instill-ai/mgmt-backend/pkg/acl"
@@ -65,8 +64,6 @@ type Service interface {
 	CheckUserPassword(ctx context.Context, uid uuid.UUID, password string) error
 	UpdateUserPassword(ctx context.Context, uid uuid.UUID, newPassword string) error
 
-	ListUserPipelines(ctx context.Context, id string) ([]*pipelinePB.Pipeline, error)
-	ListOrganizationPipelines(ctx context.Context, id string) ([]*pipelinePB.Pipeline, error)
 	ListPipelineTriggerRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerRecord, int64, string, error)
 	ListPipelineTriggerTableRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerTableRecord, int64, string, error)
 	ListPipelineTriggerChartRecords(ctx context.Context, owner *mgmtPB.User, aggregationWindow int64, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerChartRecord, error)
@@ -986,59 +983,4 @@ func (s *service) DeleteOrganizationMembership(ctx context.Context, ctxUserUID u
 		return err
 	}
 	return nil
-}
-func (s *service) ListUserPipelines(ctx context.Context, id string) ([]*pipelinePB.Pipeline, error) {
-
-	pageToken := ""
-	pageSize := int32(100)
-
-	pipelines := []*pipelinePB.Pipeline{}
-	for {
-		resp, err := s.pipelinePublicServiceClient.ListUserPipelines(
-			metadata.AppendToOutgoingContext(ctx, "instill-user-uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
-			&pipelinePB.ListUserPipelinesRequest{
-				PageSize:  &pageSize,
-				PageToken: &pageToken,
-				Parent:    fmt.Sprintf("users/%s", id),
-			},
-		)
-		if err != nil {
-			return nil, err
-		}
-		pipelines = append(pipelines, resp.Pipelines...)
-		pageToken = resp.NextPageToken
-		if pageToken == "" {
-			break
-		}
-	}
-
-	return pipelines, nil
-}
-
-func (s *service) ListOrganizationPipelines(ctx context.Context, id string) ([]*pipelinePB.Pipeline, error) {
-
-	pageToken := ""
-	pageSize := int32(100)
-
-	pipelines := []*pipelinePB.Pipeline{}
-	for {
-		resp, err := s.pipelinePublicServiceClient.ListOrganizationPipelines(
-			metadata.AppendToOutgoingContext(ctx, "instill-user-uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
-			&pipelinePB.ListOrganizationPipelinesRequest{
-				PageSize:  &pageSize,
-				PageToken: &pageToken,
-				Parent:    fmt.Sprintf("organizations/%s", id),
-			},
-		)
-		if err != nil {
-			return nil, err
-		}
-		pipelines = append(pipelines, resp.Pipelines...)
-		pageToken = resp.NextPageToken
-		if pageToken == "" {
-			break
-		}
-	}
-
-	return pipelines, nil
 }


### PR DESCRIPTION
Because

- the `instill-auth-type` header was missing when request the pipeline

This commit

- add the missing `instill-auth-type` header
