### PR TITLE
chore(worker): create temporal namespace at launch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type ServerConfig struct {
 type TemporalConfig struct {
 	HostPort   string `koanf:"hostport"`
 	Namespace  string `koanf:"namespace"`
+	Retention  string `koanf:"retention"`
 	Ca         string `koanf:"ca"`
 	Cert       string `koanf:"cert"`
 	Key        string `koanf:"key"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,6 +54,7 @@ openfga:
 temporal:
   hostport: temporal:7233
   namespace: mgmt-backend
+  retention: 1d
   ca:
   cert:
   key:

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.opentelemetry.io/otel/trace v1.16.0
+	go.temporal.io/api v1.16.0
 	go.temporal.io/sdk v1.21.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.14.0
@@ -106,7 +107,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-	go.temporal.io/api v1.16.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect


### PR DESCRIPTION
Because

- make temporal namespace programmatically created to remove the `temporal-admin-tools` container at launch

This commit

- add initialisation temporal namespace logic in the worker `main.go`
- the implementation will skip the namespace creation if it already exists