### PR TITLE
fix(worker): fix temporal cloud namespace init

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -126,7 +126,10 @@ func main() {
 	}
 	defer temporalClient.Close()
 
-	initTemporalNamespace(ctx, temporalClient)
+	// for only local temporal cluster
+	if config.Config.Temporal.Ca == "" && config.Config.Temporal.Cert == "" && config.Config.Temporal.Key == "" {
+		initTemporalNamespace(ctx, temporalClient)
+	}
 
 	w := worker.New(temporalClient, mgmtWorker.TaskQueue, worker.Options{
 		MaxConcurrentActivityExecutionSize: 2,


### PR DESCRIPTION
Because

- we can't programmatically list namespace in Temporal Cloud (i.e., `tcld` is the current only way to pass the authentication) 

This commit

- bypass the initialisation of namespace for Temporal Cloud route
