### PR TITLE
ci(Dockerfile): add sh and wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ ARG SERVICE_NAME
 
 WORKDIR /${SERVICE_NAME}
 
+COPY --from=busybox:stable-musl --chown=nonroot:nonroot /bin/sh /bin/sh
+COPY --from=busybox:stable-musl --chown=nonroot:nonroot /bin/wget /bin/wget
+
 COPY --from=build --chown=nonroot:nonroot /src/config ./config
 COPY --from=build --chown=nonroot:nonroot /src/release-please ./release-please
 COPY --from=build --chown=nonroot:nonroot /src/pkg/db/migration ./pkg/db/migration


### PR DESCRIPTION
Because

- we want fine-grained control for dependency status with healthcheck at docker compose up

This commit

- add `sh` and `wget` for distroless image 
