### PR TITLE
chore(worker): use config temporal namespace

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -23,8 +23,6 @@ import (
 	mgmtWorker "github.com/instill-ai/mgmt-backend/pkg/worker"
 )
 
-const namespace = "mgmt-backend"
-
 func initTemporalNamespace(ctx context.Context, client client.Client) {
 	logger, _ := logger.GetZapLogger(ctx)
 
@@ -35,7 +33,7 @@ func initTemporalNamespace(ctx context.Context, client client.Client) {
 
 	found := false
 	for _, n := range resp.GetNamespaces() {
-		if n.NamespaceInfo.Name == namespace {
+		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
 			found = true
 		}
 	}
@@ -43,7 +41,7 @@ func initTemporalNamespace(ctx context.Context, client client.Client) {
 	if !found {
 		if _, err := client.WorkflowService().RegisterNamespace(ctx,
 			&workflowservice.RegisterNamespaceRequest{
-				Namespace: namespace,
+				Namespace: config.Config.Temporal.Namespace,
 				WorkflowExecutionRetentionPeriod: func() *time.Duration {
 					// Check if the string ends with "d" for day.
 					s := config.Config.Temporal.Retention


### PR DESCRIPTION
Because

- config has the temporal namespace set

This commit

- replace the const namespace variable with the configured one
