### PR TITLE
fix(usage): send usage report with `AuthenticatedUser`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206143154-b35c1e6a1a01
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240222135530-192b4f25f624
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1107,8 +1107,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206143154-b35c1e6a1a01 h1:rZI+jp0LmlWsBTMvbyJ4GHQKhHxz+sfMw/oxgO/QoBI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206143154-b35c1e6a1a01/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240222135530-192b4f25f624 h1:hs3W4ex8uL1Mr+xCTsNOgsyvFvjMX1GHOdBVzWmx7DY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240222135530-192b4f25f624/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -235,6 +235,22 @@ func (s *service) DBUsers2PBUsers(ctx context.Context, dbUsers []*datamodel.Owne
 	return pbUsers, nil
 }
 
+func (s *service) DBUsers2PBAuthenticatedUsers(ctx context.Context, dbUsers []*datamodel.Owner) ([]*mgmtPB.AuthenticatedUser, error) {
+	var err error
+	pbUsers := make([]*mgmtPB.AuthenticatedUser, len(dbUsers))
+	for idx := range dbUsers {
+		pbUsers[idx], err = s.DBUser2PBAuthenticatedUser(
+			ctx,
+			dbUsers[idx],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return pbUsers, nil
+}
+
 // DBUser2PBUser converts a database user instance to proto user
 func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgmtPB.Organization, error) {
 	if dbOrg == nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -34,6 +34,7 @@ type Service interface {
 	DeleteUser(ctx context.Context, ctxUserUID uuid.UUID, id string) error
 
 	ListUsersAdmin(ctx context.Context, pageSize int, pageToken string, filter filtering.Filter) ([]*mgmtPB.User, int64, string, error)
+	ListAuthenticatedUsersAdmin(ctx context.Context, pageSize int, pageToken string, filter filtering.Filter) ([]*mgmtPB.AuthenticatedUser, int64, string, error)
 	GetUserAdmin(ctx context.Context, id string) (*mgmtPB.User, error)
 	GetUserByUIDAdmin(ctx context.Context, uid uuid.UUID) (*mgmtPB.User, error)
 
@@ -76,6 +77,7 @@ type Service interface {
 	DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*mgmtPB.User, error)
 	DBUsers2PBUsers(ctx context.Context, dbUsers []*datamodel.Owner) ([]*mgmtPB.User, error)
 	PBAuthenticatedUser2DBUser(pbUser *mgmtPB.AuthenticatedUser) (*datamodel.Owner, error)
+	DBUsers2PBAuthenticatedUsers(ctx context.Context, dbUsers []*datamodel.Owner) ([]*mgmtPB.AuthenticatedUser, error)
 
 	DBToken2PBToken(ctx context.Context, dbToken *datamodel.Token) (*mgmtPB.ApiToken, error)
 	DBTokens2PBTokens(ctx context.Context, dbTokens []*datamodel.Token) ([]*mgmtPB.ApiToken, error)
@@ -250,6 +252,15 @@ func (s *service) ListUsersAdmin(ctx context.Context, pageSize int, pageToken st
 		return nil, 0, "", fmt.Errorf("users/ with page_size=%d page_token=%s: %w", pageSize, pageToken, err)
 	}
 	pbUsers, err := s.DBUsers2PBUsers(ctx, dbUsers)
+	return pbUsers, totalSize, nextPageToken, err
+}
+
+func (s *service) ListAuthenticatedUsersAdmin(ctx context.Context, pageSize int, pageToken string, filter filtering.Filter) ([]*mgmtPB.AuthenticatedUser, int64, string, error) {
+	dbUsers, totalSize, nextPageToken, err := s.repository.ListUsers(ctx, pageSize, pageToken, filter)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("users/ with page_size=%d page_token=%s: %w", pageSize, pageToken, err)
+	}
+	pbUsers, err := s.DBUsers2PBAuthenticatedUsers(ctx, dbUsers)
 	return pbUsers, totalSize, nextPageToken, err
 }
 

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -69,10 +69,10 @@ func (u *usage) RetrieveUsageData() interface{} {
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Debug("[mgmt-backend] retrieve usage data...")
 
-	allUsers := []*mgmtPB.User{}
+	allUsers := []*mgmtPB.AuthenticatedUser{}
 	pageToken := ""
 	for {
-		users, _, token, err := u.service.ListUsersAdmin(ctx, 100, pageToken, filtering.Filter{})
+		users, _, token, err := u.service.ListAuthenticatedUsersAdmin(ctx, 100, pageToken, filtering.Filter{})
 		if err != nil {
 			logger.Error(fmt.Sprintf("%s", err))
 			break


### PR DESCRIPTION
Because

- `usage-server` is using `AuthenticatedUser` in `usage` report

This commit

- adopt latest protogen-go
- use `AuthenticatedUser` in `usage` report
