### PR TITLE
chore(deps): pin air dependency

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,7 @@ WORKDIR /${SERVICE_NAME}
 ARG TARGETOS TARGETARCH K6_VERSION
 
 # air
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/cosmtrek/air@latest
+RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/cosmtrek/air@v1.49.0
 
 # k6
 ADD https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-$TARGETARCH.tar.gz k6-v${K6_VERSION}-linux-$TARGETARCH.tar.gz


### PR DESCRIPTION
The `latest` version is incompatible with the current Go version