### PR TITLE
feat: pin the user to read from the primary database for a certain time frame after mutating the data

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 	"github.com/instill-ai/mgmt-backend/pkg/service"
+	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
@@ -48,7 +49,9 @@ func createDefaultUser(ctx context.Context, db *gorm.DB) error {
 		return status.Errorf(codes.Internal, "uuid generation error %v", err)
 	}
 
-	r := repository.NewRepository(db)
+	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
+	defer redisClient.Close()
+	r := repository.NewRepository(db, redisClient)
 
 	passwordBytes, err := bcrypt.GenerateFromPassword([]byte(constant.DefaultUserPassword), 10)
 	if err != nil {

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -182,7 +182,7 @@ func main() {
 	defer redisClient.Close()
 
 	influxDB := repository.NewInfluxDB(influxDBQueryAPI, config.Config.InfluxDB.Bucket)
-	repository := repository.NewRepository(db)
+	repository := repository.NewRepository(db, redisClient)
 	service := service.NewService(repository, redisClient, influxDB, pipelinePublicServiceClient, &aclClient)
 
 	// Start usage reporter

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/redis/go-redis/v9"
@@ -89,10 +90,11 @@ type DatabaseConfig struct {
 	Host     string `koanf:"host"`
 	Port     int    `koanf:"port"`
 	Replica  struct {
-		Username string `koanf:"username"`
-		Password string `koanf:"password"`
-		Host     string `koanf:"host"`
-		Port     int    `koanf:"port"`
+		Username             string `koanf:"username"`
+		Password             string `koanf:"password"`
+		Host                 string `koanf:"host"`
+		Port                 int    `koanf:"port"`
+		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
 	} `koanf:"replica"`
 	Name     string `koanf:"name"`
 	Version  uint   `koanf:"version"`
@@ -130,6 +132,12 @@ type LogConfig struct {
 func Init() error {
 	k := koanf.New(".")
 	parser := yaml.Parser()
+
+	if err := k.Load(confmap.Provider(map[string]interface{}{
+		"database.replica.replicationtimeframe": 180,
+	}, "."), nil); err != nil {
+		log.Fatal(err.Error())
+	}
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fileRelativePath := fs.String("file", "config/config.yaml", "configuration file")


### PR DESCRIPTION
Because

- Since there will be replication lag in the database replica, we will encounter the "read-after-write inconsistency" problem when deploying Core in a multi-region cluster. In our use case, we can choose the "Pinning User to Primary Database" approach as our first step. This means that after the user mutates some data, there will be a small time frame during which this user will always read data from the primary database, regardless of their location. This way, we can ensure read-after-write consistency.

This commit

- Pins the user to read from the primary database for a certain time frame after mutating the data.