### PR TITLE
feat: support OpenFGA read replica

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,8 +62,13 @@ type TemporalConfig struct {
 
 // OpenFGA config
 type OpenFGAConfig struct {
-	Host string `koanf:"host"`
-	Port int    `koanf:"port"`
+	Host    string `koanf:"host"`
+	Port    int    `koanf:"port"`
+	Replica struct {
+		Host                 string `koanf:"host"`
+		Port                 int    `koanf:"port"`
+		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
+	} `koanf:"replica"`
 }
 
 // CacheConfig related to Redis
@@ -134,7 +139,8 @@ func Init() error {
 	parser := yaml.Parser()
 
 	if err := k.Load(confmap.Provider(map[string]interface{}{
-		"database.replica.replicationtimeframe": 180,
+		"database.replica.replicationtimeframe": 60,
+		"openfga.replica.replicationtimeframe":  60,
 	}, "."), nil); err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -857,7 +857,7 @@ func (h *PublicHandler) ValidateToken(ctx context.Context, req *mgmtPB.ValidateT
 	authorization := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthorization)
 	apiToken := strings.Replace(authorization, "Bearer ", "", 1)
 
-	userUID, err := h.Service.ValidateToken(apiToken)
+	userUID, err := h.Service.ValidateToken(ctx, apiToken)
 
 	if err != nil {
 		span.SetStatus(1, err.Error())

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -147,7 +147,7 @@ func (s *service) DBUser2PBAuthenticatedUser(ctx context.Context, dbUser *datamo
 }
 
 // PBAuthenticatedUser2DBUser converts a proto user instance to database user
-func (s *service) PBAuthenticatedUser2DBUser(pbUser *mgmtPB.AuthenticatedUser) (*datamodel.Owner, error) {
+func (s *service) PBAuthenticatedUser2DBUser(ctx context.Context, pbUser *mgmtPB.AuthenticatedUser) (*datamodel.Owner, error) {
 	if pbUser == nil {
 		return nil, status.Error(codes.Internal, "can't convert a nil user")
 	}
@@ -260,7 +260,7 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 	id := dbOrg.ID
 	uid := dbOrg.Base.UID.String()
 
-	relations, err := s.aclClient.GetOrganizationUsers(dbOrg.Base.UID)
+	relations, err := s.aclClient.GetOrganizationUsers(ctx, dbOrg.Base.UID)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 }
 
 // PBOrg2DBOrg converts a proto user instance to database user
-func (s *service) PBOrg2DBOrg(pbOrg *mgmtPB.Organization) (*datamodel.Owner, error) {
+func (s *service) PBOrg2DBOrg(ctx context.Context, pbOrg *mgmtPB.Organization) (*datamodel.Owner, error) {
 	if pbOrg == nil {
 		return nil, status.Error(codes.Internal, "can't convert a nil organization")
 	}

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -51,7 +51,7 @@ func (s *service) checkPipelineOwnership(ctx context.Context, filter filtering.F
 				if err != nil {
 					return nil, "", "", "", filter, err
 				}
-				granted, err := s.GetACLClient().CheckPermission("organization", uuid.FromStringOrNil(org.Uid), "user", uuid.FromStringOrNil(owner.GetUid()), "", "member")
+				granted, err := s.GetACLClient().CheckPermission(ctx, "organization", uuid.FromStringOrNil(org.Uid), "user", uuid.FromStringOrNil(owner.GetUid()), "", "member")
 				if err != nil {
 					return nil, "", "", "", filter, err
 				}
@@ -98,7 +98,7 @@ func (s *service) checkConnectorOwnership(ctx context.Context, filter filtering.
 				if err != nil {
 					return nil, "", "", "", filter, err
 				}
-				granted, err := s.GetACLClient().CheckPermission("organization", uuid.FromStringOrNil(org.Uid), "user", uuid.FromStringOrNil(owner.GetUid()), "", "member")
+				granted, err := s.GetACLClient().CheckPermission(ctx, "organization", uuid.FromStringOrNil(org.Uid), "user", uuid.FromStringOrNil(owner.GetUid()), "", "member")
 				if err != nil {
 					return nil, "", "", "", filter, err
 				}


### PR DESCRIPTION
Because

- In the multi-region deployment, we will separate the read/write operations into different databases and OpenFGA engines.

This commit

- Adds connection settings for OpenFGA read replica.
- Separates read/write modes into different OpenFGA engines.