### PR TITLE
feat: implement endpoints for user and organization avatars

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -72,7 +72,7 @@ func createDefaultUser(ctx context.Context, db *gorm.DB) error {
 		OnboardingStatus:       datamodel.OnboardingStatusInProgress,
 	}
 
-	user, err := r.GetUser(context.Background(), constant.DefaultUserID)
+	user, err := r.GetUser(context.Background(), constant.DefaultUserID, false)
 	// Default user already exists
 	if err == nil {
 		passwordHash, _, err := r.GetUserPasswordHash(ctx, user.UID)

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -198,7 +198,7 @@ func main() {
 
 	influxDB := repository.NewInfluxDB(influxDBQueryAPI, config.Config.InfluxDB.Bucket)
 	repository := repository.NewRepository(db, redisClient)
-	service := service.NewService(repository, redisClient, influxDB, pipelinePublicServiceClient, &aclClient)
+	service := service.NewService(repository, redisClient, influxDB, pipelinePublicServiceClient, &aclClient, config.Config.Server.InstillCoreHost)
 
 	// Start usage reporter
 	var usg usage.Usage
@@ -268,6 +268,12 @@ func main() {
 			},
 		}),
 	)
+	if err := publicServeMux.HandlePath("GET", "/v1beta/{name=users/*}/avatar", middleware.AppendCustomHeaderMiddleware(publicServeMux, repository, middleware.HandleAvatar)); err != nil {
+		logger.Fatal(err.Error())
+	}
+	if err := publicServeMux.HandlePath("GET", "/v1beta/{name=organizations/*}/avatar", middleware.AppendCustomHeaderMiddleware(publicServeMux, repository, middleware.HandleAvatar)); err != nil {
+		logger.Fatal(err.Error())
+	}
 
 	// Start gRPC server
 	var dialOpts []grpc.DialOption

--- a/config/config.go
+++ b/config/config.go
@@ -45,8 +45,9 @@ type ServerConfig struct {
 		Host       string `koanf:"host"`
 		Port       int    `koanf:"port"`
 	}
-	Debug          bool   `koanf:"debug"`
-	DefaultUserUID string `koanf:"defaultuseruid"`
+	Debug           bool   `koanf:"debug"`
+	DefaultUserUID  string `koanf:"defaultuseruid"`
+	InstillCoreHost string `koanf:"instillcorehost"`
 }
 
 // TemporalConfig related to Temporal

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,7 @@ server:
     port: 443
   debug: true
   defaultuseruid:
+  instillcorehost: http://localhost:8080
 pipelinebackend:
   host: pipeline-backend
   publicport: 8081

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+
+	"github.com/instill-ai/mgmt-backend/pkg/repository"
+)
+
+type fn func(*runtime.ServeMux, repository.Repository, http.ResponseWriter, *http.Request, map[string]string)
+
+// AppendCustomHeaderMiddleware appends custom headers
+func AppendCustomHeaderMiddleware(mux *runtime.ServeMux, repository repository.Repository, next fn) runtime.HandlerFunc {
+	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		next(mux, repository, w, r, pathParams)
+	})
+}
+
+func HandleAvatar(mux *runtime.ServeMux, repository repository.Repository, w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
+	defer cancel()
+	if v, ok := pathParams["name"]; !ok || len(strings.Split(v, "/")) < 2 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	avatarBase64 := ""
+	if strings.Split(pathParams["name"], "/")[0] == "users" {
+		user, err := repository.GetUser(ctx, strings.Split(pathParams["name"], "/")[1], true)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if user.ProfileAvatar.String == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		avatarBase64 = user.ProfileAvatar.String
+	} else if strings.Split(pathParams["name"], "/")[0] == "organizations" {
+		org, err := repository.GetOrganization(ctx, strings.Split(pathParams["name"], "/")[1], true)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if org.ProfileAvatar.String == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		avatarBase64 = org.ProfileAvatar.String
+	}
+
+	b, err := base64.StdEncoding.DecodeString(strings.Split(avatarBase64, ",")[1])
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	_, err = w.Write(b)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -61,7 +61,7 @@ func TestRepository_CreateUser(t *testing.T) {
 	err := repo.CreateUser(ctx, user)
 	c.Check(err, qt.IsNil)
 
-	got, err := repo.GetUser(ctx, id)
+	got, err := repo.GetUser(ctx, id, false)
 	c.Check(err, qt.IsNil)
 	c.Check(got.CreateTime.After(t0), qt.IsTrue)
 	c.Check(got.UpdateTime.After(t0), qt.IsTrue)

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -11,6 +11,8 @@ import (
 	"image"
 	"image/jpeg"
 	"image/png"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -42,6 +44,19 @@ var (
 )
 
 func (s *service) compressAvatar(profileAvatar string) (string, error) {
+
+	if strings.HasPrefix(profileAvatar, "http") {
+		response, err := http.Get(profileAvatar)
+		if err == nil {
+			body, err := io.ReadAll(response.Body)
+			if err == nil {
+				mimeType := strings.Split(mimetype.Detect(body).String(), ";")[0]
+				profileAvatar = fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(body))
+			}
+		}
+		defer response.Body.Close()
+	}
+
 	profileAvatarStrs := strings.Split(profileAvatar, ",")
 	b, err := base64.StdEncoding.DecodeString(profileAvatarStrs[len(profileAvatarStrs)-1])
 	if err != nil {
@@ -92,6 +107,7 @@ func (s *service) DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*
 		_ = json.Unmarshal(b, &socialProfileLinks)
 	}
 
+	avatar := fmt.Sprintf("%s/core/v1beta/users/%s/avatar", s.instillCoreHost, dbUser.ID)
 	return &mgmtPB.User{
 		Name:       fmt.Sprintf("users/%s", id),
 		Uid:        &uid,
@@ -102,7 +118,7 @@ func (s *service) DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*
 			DisplayName:        &dbUser.DisplayName.String,
 			CompanyName:        &dbUser.CompanyName.String,
 			PublicEmail:        &dbUser.PublicEmail.String,
-			Avatar:             &dbUser.ProfileAvatar.String,
+			Avatar:             &avatar,
 			Bio:                &dbUser.Bio.String,
 			SocialProfileLinks: socialProfileLinks,
 		},
@@ -123,6 +139,7 @@ func (s *service) DBUser2PBAuthenticatedUser(ctx context.Context, dbUser *datamo
 		_ = json.Unmarshal(b, &socialProfileLinks)
 	}
 
+	avatar := fmt.Sprintf("%s/core/v1beta/users/%s/avatar", s.instillCoreHost, dbUser.ID)
 	return &mgmtPB.AuthenticatedUser{
 		Name:                   fmt.Sprintf("users/%s", id),
 		Uid:                    &uid,
@@ -138,7 +155,7 @@ func (s *service) DBUser2PBAuthenticatedUser(ctx context.Context, dbUser *datamo
 			DisplayName:        &dbUser.DisplayName.String,
 			CompanyName:        &dbUser.CompanyName.String,
 			PublicEmail:        &dbUser.PublicEmail.String,
-			Avatar:             &dbUser.ProfileAvatar.String,
+			Avatar:             &avatar,
 			Bio:                &dbUser.Bio.String,
 			SocialProfileLinks: socialProfileLinks,
 		},
@@ -282,6 +299,8 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 		_ = json.Unmarshal(b, &socialProfileLinks)
 	}
 
+	avatar := fmt.Sprintf("%s/core/v1beta/organizations/%s/avatar", s.instillCoreHost, dbOrg.ID)
+
 	return &mgmtPB.Organization{
 		Name:       fmt.Sprintf("organizations/%s", id),
 		Uid:        uid,
@@ -291,7 +310,7 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 		Profile: &mgmtPB.OrganizationProfile{
 			DisplayName:        &dbOrg.DisplayName.String,
 			PublicEmail:        &dbOrg.PublicEmail.String,
-			Avatar:             &dbOrg.ProfileAvatar.String,
+			Avatar:             &avatar,
 			Bio:                &dbOrg.Bio.String,
 			SocialProfileLinks: socialProfileLinks,
 		},

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -48,13 +48,17 @@ func (s *service) compressAvatar(profileAvatar string) (string, error) {
 	if strings.HasPrefix(profileAvatar, "http") {
 		response, err := http.Get(profileAvatar)
 		if err == nil {
+			defer response.Body.Close()
 			body, err := io.ReadAll(response.Body)
 			if err == nil {
 				mimeType := strings.Split(mimetype.Detect(body).String(), ";")[0]
 				profileAvatar = fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(body))
+			} else {
+				return "", nil
 			}
+		} else {
+			return "", nil
 		}
-		defer response.Body.Close()
 	}
 
 	profileAvatarStrs := strings.Split(profileAvatar, ",")


### PR DESCRIPTION
Because

- Putting the avatar as base64 in the user, organization and pipeline response is not a good choice. We should provide a link for the Console to fetch the avatar asynchronously.

This commit

- Implements endpoints for user and organization avatars.