### PR TITLE
feat: update credit datamodel

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -119,7 +119,7 @@ func (o OnboardingStatus) Value() (driver.Value, error) {
 
 // Credit defines an amount of Instill Credit.
 type Credit struct {
-	Owner      string
+	OwnerUID   uuid.UUID
 	Amount     float64
 	ExpireTime sql.NullTime
 

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -117,7 +117,9 @@ func (o OnboardingStatus) Value() (driver.Value, error) {
 	return mgmtPB.OnboardingStatus(o).String(), nil
 }
 
-// Credit defines an amount of Instill Credit.
+// Credit defines a positive or negative amount of Instill Credit. The database
+// table adds as a ledger for credit entries. It should only take insertions,
+// no updates.
 type Credit struct {
 	OwnerUID   uuid.UUID
 	Amount     float64

--- a/pkg/db/migration/000006_init.up.sql
+++ b/pkg/db/migration/000006_init.up.sql
@@ -17,8 +17,7 @@ CREATE TABLE IF NOT EXISTS credit (
 );
 
 CREATE INDEX IF NOT EXISTS credit_index_remaining
-  ON credit (owner_uid, (amount > 0), expire_time DESC)
-  WHERE amount > 0;
+  ON credit (owner_uid, expire_time ASC);
 
 CREATE TRIGGER tg_update_time_credit
   BEFORE UPDATE ON credit

--- a/pkg/db/migration/000006_init.up.sql
+++ b/pkg/db/migration/000006_init.up.sql
@@ -9,7 +9,7 @@ $$ language 'plpgsql';
 
 CREATE TABLE IF NOT EXISTS credit (
   uid         UUID          DEFAULT gen_random_uuid() PRIMARY KEY,
-  owner       VARCHAR(255)                            NOT NULL,
+  owner_uid   UUID                                    NOT NULL,
   amount      DECIMAL(16,8)                           NOT NULL,
   expire_time TIMESTAMPTZ,
   create_time TIMESTAMPTZ   DEFAULT CURRENT_TIMESTAMP NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS credit (
 );
 
 CREATE INDEX IF NOT EXISTS credit_index_remaining
-  ON credit (owner, (amount > 0), expire_time DESC)
+  ON credit (owner_uid, (amount > 0), expire_time DESC)
   WHERE amount > 0;
 
 CREATE TRIGGER tg_update_time_credit

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -595,7 +595,7 @@ func (r *repository) SubtractCredit(ctx context.Context, ownerUID uuid.UUID, amo
 }
 
 // Acquire an exclusive advisory lock for the provided key. This allows us to
-// lock a resource withouth having an associated row in the database, e.g.
+// lock a resource without having an associated row in the database, e.g.
 // locking the credit ledger of a user (where we fetch the records with a GROUP
 // BY statement, which doesn't allow for locks).
 func acquireTxLock(ctx context.Context, tx *gorm.DB, key string) error {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -475,15 +475,19 @@ func (r *repository) AddCredit(ctx context.Context, credit datamodel.Credit) err
 
 type remainingCredit struct {
 	Total float64
+
+	// ExpireTime will be used for subtraction, when we group by this column.
+	ExpireTime sql.NullTime
 }
 
+// GetRemainingCredit is computed as the sum of entries of a owner that aren't
+// expired.
 func (r *repository) GetRemainingCredit(ctx context.Context, ownerUID uuid.UUID) (float64, error) {
 	db := r.checkPinnedUser(ctx, r.db)
 
 	var result remainingCredit
 	q := db.Model(datamodel.Credit{}).Select("sum(amount) as total").
 		Where("owner_uid = ?", ownerUID).
-		Where("amount > 0").
 		Where("expire_time is null or expire_time > ?", time.Now()).
 		Group("owner_uid")
 
@@ -501,50 +505,74 @@ func (r *repository) GetRemainingCredit(ctx context.Context, ownerUID uuid.UUID)
 // what's available. The owner's remaining credit will be set to zero.
 var ErrNotEnoughCredit = fmt.Errorf("not enough credit")
 
+// Because entries might expire (users get free monthly credit), when
+// subtracting credit we need to:
+// 1. Cancel out credit that has an expiration date. The negative entry will
+// have an expiration date.
+// 2. If there's remaining credit to be subtracted, cancel out non-expiring
+// credit.
+//
+// That way, when computing the remaining credit we'll only take into account
+// credit that doesn't expire or credit within the period.
+// If the number of entries grows too big over time, this won't be as efficient
+// as keeping a separate table with the balance. For now, this is simple than
+// recomputing the balance when an entry expires.
 func (r *repository) SubtractCredit(ctx context.Context, ownerUID uuid.UUID, amount float64) error {
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
-
-	q := db.Model(datamodel.Credit{}).
-		Where("owner_uid = ?", ownerUID).
-		Where("amount > 0").
-		Where("expire_time is null or expire_time > ?", time.Now()).
-		Order("expire_time asc")
-
-	rows, err := q.Rows()
-	if err != nil {
-		return err
+	if amount <= 0 {
+		return fmt.Errorf("only positive amounts are allowed")
 	}
-	defer rows.Close()
 
-	updatedRows := make([]*datamodel.Credit, 0)
-	for rows.Next() {
-		credit := new(datamodel.Credit)
-		if err := db.ScanRows(rows, credit); err != nil {
+	r.pinUser(ctx)
+	db := r.checkPinnedUser(ctx, r.db).WithContext(ctx)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		q := tx.Model(datamodel.Credit{}).
+			Select("sum(amount) as total", "expire_time").
+			Where("owner_uid = ?", ownerUID).
+			Where("expire_time is null or expire_time > ?", time.Now()).
+			Group("expire_time")
+
+		rows, err := q.Rows()
+		if err != nil {
 			return err
 		}
+		defer rows.Close()
 
-		updatedRows = append(updatedRows, credit)
-		diff := credit.Amount - amount
-		if diff >= 0 { // credit is enough.
-			updatedRows = append(updatedRows, credit)
-			credit.Amount = diff
-			amount = 0
+		// Instead of entering a single negative amount, we cancel first the
+		// credit entries that have an expiration date. The negative entries
+		// will have, in this case, the same expiration date as the positive
+		// one.
+		entriesToCancel := []*datamodel.Credit{}
+		for rows.Next() {
+			remaining := new(remainingCredit)
+			if err := tx.ScanRows(rows, remaining); err != nil {
+				return err
+			}
 
-			rows.Close()
-			break
+			entry := &datamodel.Credit{
+				OwnerUID:   ownerUID,
+				ExpireTime: remaining.ExpireTime,
+			}
+			entriesToCancel = append(entriesToCancel, entry)
+
+			diff := remaining.Total - amount
+			if diff >= 0 { // credit is enough.
+				entry.Amount = -amount
+				amount = 0
+
+				rows.Close()
+				break
+			}
+
+			// set credit to zero and continue subtracting the remaining amount.
+			entry.Amount = -remaining.Total
+			amount = -diff
+
 		}
 
-		// set credit to zero and continue subtracting the remaining amount.
-		credit.Amount = 0
-		amount = -diff
-	}
-
-	err = db.Transaction(func(tx *gorm.DB) error {
-		for _, row := range updatedRows {
-			result := tx.Model(datamodel.Credit{}).Where("uid = ?", row.UID).Update("amount", row.Amount)
-			if result.Error != nil {
-				return result.Error
+		for _, entry := range entriesToCancel {
+			if err := tx.Create(entry).Error; err != nil {
+				return err
 			}
 		}
 


### PR DESCRIPTION
Because

- Credit table references the owner by ID but it is a field that might become modifiable.
- We want to trace the credit history of an owner.
- We need to avoid concurrent credit subtractions to corrupt data (subtraction starts by checking the remaining credit).

This commit

- Updates the table to reference the `user_uid`
- Updates the indices and subtraction method to only add entries, not update them. The credit table becomes a ledger with positive and negative entries.
  - Since we have entries that expire, we'll need to cancel them separately to compute the credit successfully.
- A lock mechanism is added to avoid concurrent subtractions to conflict between them.

# Notes
- This [ledger test](https://github.com/instill-ai/mgmt-backend/pull/198/files#diff-650c1756664dfa9c6d895fbb31ad66a26d0b57eb527a99f4f27a3e2404ecf827R159) illustrates how credit subtraction, addition and retrieval should work.
- @donch1989 it's unorthodox to update the migration script but, if this [hasn't been deployed yet](https://github.com/instill-ai/instill-core/blob/main/charts/core/values.yaml#L335) (and the migration version seems yet to be updated), we can afford this and the migration history will be clearer.
