### PR TITLE
test: remove /core HTTP endpoint prefix in integration test

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -14,7 +14,7 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 }
 export const mgmtVersion = "v1beta";
 export const mgmtPrivateHost = apiGatewayMode ? "" : `http://mgmt-backend:3084/${mgmtVersion}`
-export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/core/${mgmtVersion}` : `http://mgmt-backend:8084/${mgmtVersion}`
+export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/${mgmtVersion}` : `http://mgmt-backend:8084/${mgmtVersion}`
 
 export const mgmtPrivateGRPCHost = `mgmt-backend:3084`
 export const mgmtPublicGRPCHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `mgmt-backend:8084`


### PR DESCRIPTION
Because

- We've added new HTTP endpoints without the `/core` prefix.

This commit

- Removes the `/core` HTTP endpoint prefix in HTTP integration test.