### PR TITLE
chore: export database user pinning logic

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -23,10 +23,18 @@ import (
 
 type CtxKey string
 
+// UserUIDCtxKey must be present in the context in order to pin a user to the
+// primary database.
+// TODO we shouldn't force parent packages to be aware of this context key. All
+// authenticated requests and endpoints modifying a user resource should
+// add this key (defined in a common package) to the context.
 const UserUIDCtxKey CtxKey = "userUID"
 
 // Repository interface
 type Repository interface {
+	PinUser(context.Context)
+	CheckPinnedUser(context.Context, *gorm.DB) *gorm.DB
+
 	GetAllUsers(ctx context.Context) ([]*datamodel.Owner, error)
 
 	ListUsers(ctx context.Context, pageSize int, pageToken string, filter filtering.Filter) ([]*datamodel.Owner, int64, string, error)
@@ -75,20 +83,22 @@ func NewRepository(db *gorm.DB, redisClient *redis.Client) Repository {
 	}
 }
 
-func (r *repository) checkPinnedUser(ctx context.Context, db *gorm.DB) *gorm.DB {
+// CheckPinnedUser uses the primary database for querying if the user is
+// pinned. This is used to solve read-after-write inconsistency problems on
+// multi-region setups.
+func (r *repository) CheckPinnedUser(ctx context.Context, db *gorm.DB) *gorm.DB {
 	userUID := ctx.Value(UserUIDCtxKey)
-	// If the user is pinned, we will use the primary database for querying.
 	if !errors.Is(r.redisClient.Get(ctx, fmt.Sprintf("db_pin_user:%s", userUID)).Err(), redis.Nil) {
 		db = db.Clauses(dbresolver.Write)
 	}
-	return db
+	return db.WithContext(ctx)
 }
 
-func (r *repository) pinUser(ctx context.Context) {
+// PinUser sets the primary database as the read of the user for a certain
+// period to ensure that the data is synchronized from the primary DB to the
+// replica DB.
+func (r *repository) PinUser(ctx context.Context) {
 	userUID := ctx.Value(UserUIDCtxKey)
-	// To solve the read-after-write inconsistency problem,
-	// we will direct the user to read from the primary database for a certain time frame
-	// to ensure that the data is synchronized from the primary DB to the replica DB.
 	_ = r.redisClient.Set(ctx, fmt.Sprintf("db_pin_user:%s", userUID), time.Now(), time.Duration(config.Config.Database.Replica.ReplicationTimeFrame)*time.Second)
 }
 
@@ -131,7 +141,7 @@ func (r *repository) DeleteOrganization(ctx context.Context, id string) error {
 }
 
 func (r *repository) GetAllUsers(ctx context.Context) ([]*datamodel.Owner, error) {
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 	logger, _ := logger.GetZapLogger(ctx)
 	var users []*datamodel.Owner
 	if result := db.Find(users).Where("owner_type = 'user'"); result.Error != nil {
@@ -143,7 +153,7 @@ func (r *repository) GetAllUsers(ctx context.Context) ([]*datamodel.Owner, error
 
 func (r *repository) listOwners(ctx context.Context, ownerType string, pageSize int, pageToken string, filter filtering.Filter) ([]*datamodel.Owner, int64, string, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logger.GetZapLogger(ctx)
 	totalSize := int64(0)
@@ -214,8 +224,8 @@ func (r *repository) listOwners(ctx context.Context, ownerType string, pageSize 
 
 func (r *repository) createOwner(ctx context.Context, ownerType string, owner *datamodel.Owner) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	if ownerType != owner.OwnerType.String {
 		return ErrOwnerTypeNotMatch
@@ -231,7 +241,7 @@ func (r *repository) createOwner(ctx context.Context, ownerType string, owner *d
 
 func (r *repository) getOwner(ctx context.Context, ownerType string, id string, includeAvatar bool) (*datamodel.Owner, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	var owner datamodel.Owner
 	queryBuilder := db.Model(&datamodel.Owner{}).Where("owner_type = ?", ownerType).Where("id = ?", id)
@@ -246,7 +256,7 @@ func (r *repository) getOwner(ctx context.Context, ownerType string, id string, 
 
 func (r *repository) getOwnerByUID(ctx context.Context, ownerType string, uid uuid.UUID) (*datamodel.Owner, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	var owner datamodel.Owner
 	if result := db.Model(&datamodel.Owner{}).Omit("profile_avatar").Where("owner_type = ?", ownerType).Where("uid = ?", uid.String()).First(&owner); result.Error != nil {
@@ -257,8 +267,8 @@ func (r *repository) getOwnerByUID(ctx context.Context, ownerType string, uid uu
 
 func (r *repository) updateOwner(ctx context.Context, ownerType string, id string, owner *datamodel.Owner) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logger.GetZapLogger(ctx)
 	if result := db.Select("*").Omit("UID").Omit("password_hash").Model(&datamodel.Owner{}).Where("owner_type = ?", ownerType).Where("id = ?", id).Updates(owner); result.Error != nil {
@@ -270,8 +280,8 @@ func (r *repository) updateOwner(ctx context.Context, ownerType string, id strin
 
 func (r *repository) deleteOwner(ctx context.Context, ownerType string, id string) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logger.GetZapLogger(ctx)
 	result := db.Model(&datamodel.Owner{}).
@@ -296,7 +306,7 @@ func (r *repository) deleteOwner(ctx context.Context, ownerType string, id strin
 //   - codes.NotFound
 func (r *repository) GetUserPasswordHash(ctx context.Context, uid uuid.UUID) (string, time.Time, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	var pw datamodel.Password
 	if result := db.First(&pw, "uid = ?", uid.String()); result.Error != nil {
@@ -307,8 +317,8 @@ func (r *repository) GetUserPasswordHash(ctx context.Context, uid uuid.UUID) (st
 
 func (r *repository) UpdateUserPasswordHash(ctx context.Context, uid uuid.UUID, newPassword string, updateTime time.Time) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logger.GetZapLogger(ctx)
 	if result := db.Select("*").Omit("UID").Model(&datamodel.Password{}).Where("uid = ?", uid.String()).Updates(datamodel.Password{
@@ -324,7 +334,7 @@ func (r *repository) UpdateUserPasswordHash(ctx context.Context, uid uuid.UUID, 
 // TODO: use general filter
 func (r *repository) ListAllValidTokens(ctx context.Context) (tokens []datamodel.Token, err error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	queryBuilder := db.Model(&datamodel.Token{}).Where("state = ?", datamodel.TokenState(mgmtPB.ApiToken_STATE_ACTIVE))
 	queryBuilder.Where("expire_time >= ?", time.Now())
@@ -347,7 +357,7 @@ func (r *repository) ListAllValidTokens(ctx context.Context) (tokens []datamodel
 
 func (r *repository) ListTokens(ctx context.Context, owner string, pageSize int64, pageToken string) (tokens []*datamodel.Token, totalSize int64, nextPageToken string, err error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	if result := db.Model(&datamodel.Token{}).Where("owner = ?", owner).Count(&totalSize); result.Error != nil {
 		return nil, 0, "", err
@@ -407,8 +417,8 @@ func (r *repository) ListTokens(ctx context.Context, owner string, pageSize int6
 
 func (r *repository) CreateToken(ctx context.Context, token *datamodel.Token) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logger.GetZapLogger(ctx)
 	if result := db.Model(&datamodel.Token{}).Create(token); result.Error != nil {
@@ -420,7 +430,7 @@ func (r *repository) CreateToken(ctx context.Context, token *datamodel.Token) er
 
 func (r *repository) GetToken(ctx context.Context, owner string, id string) (*datamodel.Token, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	queryBuilder := db.Model(&datamodel.Token{}).Where("id = ? AND owner = ?", id, owner)
 	var token datamodel.Token
@@ -432,7 +442,7 @@ func (r *repository) GetToken(ctx context.Context, owner string, id string) (*da
 
 func (r *repository) LookupToken(ctx context.Context, accessToken string) (*datamodel.Token, error) {
 
-	db := r.checkPinnedUser(ctx, r.db)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	queryBuilder := db.Model(&datamodel.Token{}).Where("access_token = ?", accessToken)
 	var token datamodel.Token
@@ -444,8 +454,8 @@ func (r *repository) LookupToken(ctx context.Context, accessToken string) (*data
 
 func (r *repository) DeleteToken(ctx context.Context, owner string, id string) error {
 
-	r.pinUser(ctx)
-	db := r.checkPinnedUser(ctx, r.db)
+	r.PinUser(ctx)
+	db := r.CheckPinnedUser(ctx, r.db)
 
 	result := db.Model(&datamodel.Token{}).
 		Where("id = ? AND owner = ?", id, owner).


### PR DESCRIPTION
Because

- Cloud has custom database methods that also need user pinning.

This commit

- Exports the `CheckPinnedUser` and `PinUser` methods to avoid code duplication.
