### PR TITLE
feat: use camelCase for HTTP body

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -244,7 +244,6 @@ func main() {
 		runtime.WithErrorHandler(middleware.ErrorHandler),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
-				UseProtoNames:   true,
 				EmitUnpopulated: true,
 				UseEnumNumbers:  false,
 			},

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -46,10 +46,10 @@ export const defaultUser = {
   name: "users/admin",
   id: "admin",
   email: "hello@instill.tech",
-  customer_id: "",
+  customerId: "",
   profile: {
-    display_name: "Instill AI",
-    company_name: "Instill AI",
+    displayName: "Instill AI",
+    companyName: "Instill AI",
   },
   role: "hobbyist",
   newsletter_subscription: true,

--- a/integration-test/grpc-private-user.js
+++ b/integration-test/grpc-private-user.js
@@ -33,7 +33,7 @@ export function CheckPrivateListUsersAdmin() {
     }), {
       'core.mgmt.v1beta.MgmtPrivateService/ListUsersAdmin page_size=0 status': (r) => r && r.status == grpc.StatusOK,
       'core.mgmt.v1beta.MgmtPrivateService/ListUsersAdmin page_size=0 response all records': (r) => r && r.message.users.length === res.message.users.length,
-      'core.mgmt.v1beta.MgmtPrivateService/ListUsersAdmin page_size=0 response total_size 1': (r) => r && r.message.totalSize === res.message.totalSize,
+      'core.mgmt.v1beta.MgmtPrivateService/ListUsersAdmin page_size=0 response totalSize 1': (r) => r && r.message.totalSize === res.message.totalSize,
     });
 
     check(client.invoke('core.mgmt.v1beta.MgmtPrivateService/ListUsersAdmin', {

--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -71,13 +71,13 @@ export function CheckPublicPatchAuthenticatedUser(header) {
     var userUpdate = {
       name: `users/${constant.defaultUser.id}`,
       email: "test@foo.bar",
-      customer_id: "new_customer_id",
+      customerId: "new_customer_id",
       profile: {
-        display_name: "test",
-        company_name: "company",
+        displayName: "test",
+        companyName: "company",
       },
       role: "ai-engineer",
-      newsletter_subscription: true,
+      newsletterSubscription: true,
     };
 
     var res = client.invoke('core.mgmt.v1beta.MgmtPublicService/GetAuthenticatedUser', {}, header)
@@ -91,10 +91,10 @@ export function CheckPublicPatchAuthenticatedUser(header) {
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response uid unchanged': (r) => r && r.message.user.uid === res.message.user.uid,
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response id unchanged': (r) => r && r.message.user.id === res.message.user.id,
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response email updated': (r) => r && r.message.user.email === userUpdate.email,
-      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response displayName updated': (r) => r && r.message.user.profile.displayName === userUpdate.profile.display_name,
-      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response companyName updated': (r) => r && r.message.user.profile.companyName === userUpdate.profile.company_name,
+      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response displayName updated': (r) => r && r.message.user.profile.displayName === userUpdate.profile.displayName,
+      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response companyName updated': (r) => r && r.message.user.profile.companyName === userUpdate.profile.companyName,
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response role updated': (r) => r && r.message.user.role === userUpdate.role,
-      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response newsletterSubscription updated': (r) => r && r.message.user.newsletterSubscription === userUpdate.newsletter_subscription,
+      'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response newsletterSubscription updated': (r) => r && r.message.user.newsletterSubscription === userUpdate.newsletterSubscription,
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response createTime unchanged': (r) => r && r.message.user.createTime === res.message.user.createTime,
       'core.mgmt.v1beta.MgmtPublicService/PatchAuthenticatedUser response updateTime updated': (r) => r && r.message.user.updateTime !== res.message.user.updateTime,
     });
@@ -257,16 +257,16 @@ export function CheckPublicMetrics(header) {
     check(client.invoke('core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords', {}, header), {
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords status': (r) => r && r.status == grpc.StatusOK,
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords response has pipelineTriggerRecords': (r) => r && r.message.pipelineTriggerRecords !== undefined,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords response has total_size': (r) => r && r.message.totalSize !== undefined,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords response has next_page_token': (r) => r && r.message.nextPageToken !== undefined,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords response has totalSize': (r) => r && r.message.totalSize !== undefined,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords response has nextPageToken': (r) => r && r.message.nextPageToken !== undefined,
     });
     check(client.invoke('core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords', {
       filter: `pipeline_id="${pipeline_id}" AND trigger_mode=MODE_SYNC`,
     }, header), {
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter status': (r) => r && r.status == grpc.StatusOK,
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter response pipelineTriggerRecords length is 0': (r) => r && r.message.pipelineTriggerRecords.length === 0,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter response total_size is 0': (r) => r && r.message.totalSize === emptyPipelineTriggerRecordResponse.totalSize,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter response next_page_token is empty': (r) => r && r.message.nextPageToken === emptyPipelineTriggerRecordResponse.nextPageToken,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter response totalSize is 0': (r) => r && r.message.totalSize === emptyPipelineTriggerRecordResponse.totalSize,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerRecords with filter response nextPageToken is empty': (r) => r && r.message.nextPageToken === emptyPipelineTriggerRecordResponse.nextPageToken,
     });
 
   });
@@ -282,16 +282,16 @@ export function CheckPublicMetrics(header) {
     check(client.invoke('core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords', {}, header), {
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords status': (r) => r && r.status == grpc.StatusOK,
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords response has pipelineTriggerTableRecords': (r) => r && r.message.pipelineTriggerTableRecords !== undefined,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords response has total_size': (r) => r && r.message.totalSize !== undefined,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords response has next_page_token': (r) => r && r.message.nextPageToken !== undefined,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords response has totalSize': (r) => r && r.message.totalSize !== undefined,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords response has nextPageToken': (r) => r && r.message.nextPageToken !== undefined,
     });
     check(client.invoke('core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords', {
       filter: `pipeline_id="${pipeline_id}"`,
     }, header), {
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter status': (r) => r && r.status == grpc.StatusOK,
       'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter response pipelineTriggerTableRecords length is 0': (r) => r && r.message.pipelineTriggerTableRecords.length === 0,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter response total_size is 0': (r) => r && r.message.totalSize === emptyPipelineTriggerTableRecordResponse.totalSize,
-      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter response next_page_token is empty': (r) => r && r.message.nextPageToken === emptyPipelineTriggerTableRecordResponse.nextPageToken,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter response totalSize is 0': (r) => r && r.message.totalSize === emptyPipelineTriggerTableRecordResponse.totalSize,
+      'core.mgmt.v1beta.MgmtPublicService/ListPipelineTriggerTableRecords with filter response nextPageToken is empty': (r) => r && r.message.nextPageToken === emptyPipelineTriggerTableRecordResponse.nextPageToken,
     });
 
   });

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -27,7 +27,7 @@ export function setup() {
 
   return {
     "metadata": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     }
   }
 }

--- a/integration-test/rest-public-user.js
+++ b/integration-test/rest-public-user.js
@@ -42,20 +42,20 @@ export function CheckPublicGetUser(header) {
           (r) => r.json().user.id === constant.defaultUser.id,
         [`GET /${constant.mgmtVersion}/user response email`]:
           (r) => r.json().user.email !== undefined,
-        [`GET /${constant.mgmtVersion}/user response customer_id`]:
-          (r) => r.json().user.customer_id !== undefined,
-        [`GET /${constant.mgmtVersion}/user response display_name`]:
-          (r) => r.json().user.profile.display_name !== undefined,
-        [`GET /${constant.mgmtVersion}/user response company_name`]:
-          (r) => r.json().user.profile.company_name !== undefined,
+        [`GET /${constant.mgmtVersion}/user response customerId`]:
+          (r) => r.json().user.customerId !== undefined,
+        [`GET /${constant.mgmtVersion}/user response displayName`]:
+          (r) => r.json().user.profile.displayName !== undefined,
+        [`GET /${constant.mgmtVersion}/user response companyName`]:
+          (r) => r.json().user.profile.companyName !== undefined,
         [`GET /${constant.mgmtVersion}/user response role`]:
           (r) => r.json().user.role !== undefined,
-        [`GET /${constant.mgmtVersion}/user response newsletter_subscription`]:
-          (r) => r.json().user.newsletter_subscription !== undefined,
-        [`GET /${constant.mgmtVersion}/user response create_time`]:
-          (r) => r.json().user.create_time !== undefined,
-        [`GET /${constant.mgmtVersion}/user response update_time`]:
-          (r) => r.json().user.update_time !== undefined,
+        [`GET /${constant.mgmtVersion}/user response newsletterSubscription`]:
+          (r) => r.json().user.newsletterSubscription !== undefined,
+        [`GET /${constant.mgmtVersion}/user response createTime`]:
+          (r) => r.json().user.createTime !== undefined,
+        [`GET /${constant.mgmtVersion}/user response updateTime`]:
+          (r) => r.json().user.updateTime !== undefined,
       }
     )
   })
@@ -65,15 +65,15 @@ export function CheckPublicPatchAuthenticatedUser(header) {
   group(`Management Public API: Update authenticated user`, () => {
     var userUpdate = {
       email: "test@foo.bar",
-      customer_id: "new_customer_id",
+      customerId: "new_customer_id",
       profile: {
-        display_name: "test",
-        company_name: "company",
+        displayName: "test",
+        companyName: "company",
       },
       role: "ai-engineer",
-      newsletter_subscription: true,
-      create_time: "2000-01-01T00:00:00.000000Z",
-      update_time: "2000-01-01T00:00:00.000000Z",
+      newsletterSubscription: true,
+      createTime: "2000-01-01T00:00:00.000000Z",
+      updateTime: "2000-01-01T00:00:00.000000Z",
     };
 
     var res = http.request(
@@ -99,22 +99,22 @@ export function CheckPublicPatchAuthenticatedUser(header) {
           (r) => r.json().user.id === res.json().user.id,
         [`PATCH /${constant.mgmtVersion}/user response email updated`]:
           (r) => r.json().user.email === userUpdate.email,
-        [`PATCH /${constant.mgmtVersion}/user response customer_id unchanged`]:
-          (r) => r.json().user.customer_id === res.json().user.customer_id,
-        [`PATCH /${constant.mgmtVersion}/user response display_name updated`]:
-          (r) => r.json().user.profile.display_name === userUpdate.profile.display_name,
-        [`PATCH /${constant.mgmtVersion}/user response company_name updated`]:
-          (r) => r.json().user.profile.company_name === userUpdate.profile.company_name,
+        [`PATCH /${constant.mgmtVersion}/user response customerId unchanged`]:
+          (r) => r.json().user.customerId === res.json().user.customerId,
+        [`PATCH /${constant.mgmtVersion}/user response displayName updated`]:
+          (r) => r.json().user.profile.displayName === userUpdate.profile.displayName,
+        [`PATCH /${constant.mgmtVersion}/user response companyName updated`]:
+          (r) => r.json().user.profile.companyName === userUpdate.profile.companyName,
         [`PATCH /${constant.mgmtVersion}/user response role updated`]:
           (r) => r.json().user.role === userUpdate.role,
-        [`PATCH /${constant.mgmtVersion}/user response newsletter_subscription updated`]:
-          (r) => r.json().user.newsletter_subscription === userUpdate.newsletter_subscription,
-        [`PATCH /${constant.mgmtVersion}/user response create_time unchanged`]:
-          (r) => r.json().user.create_time === res.json().user.create_time,
-        [`PATCH /${constant.mgmtVersion}/user response update_time updated`]:
-          (r) => r.json().user.update_time !== res.json().user.update_time,
-        [`PATCH /${constant.mgmtVersion}/user response update_time not updated with request value`]:
-          (r) => r.json().user.update_time !== userUpdate.update_time,
+        [`PATCH /${constant.mgmtVersion}/user response newsletterSubscription updated`]:
+          (r) => r.json().user.newsletterSubscription === userUpdate.newsletterSubscription,
+        [`PATCH /${constant.mgmtVersion}/user response createTime unchanged`]:
+          (r) => r.json().user.createTime === res.json().user.createTime,
+        [`PATCH /${constant.mgmtVersion}/user response updateTime updated`]:
+          (r) => r.json().user.updateTime !== res.json().user.updateTime,
+        [`PATCH /${constant.mgmtVersion}/user response updateTime not updated with request value`]:
+          (r) => r.json().user.updateTime !== userUpdate.updateTime,
       }
     );
 
@@ -287,11 +287,11 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response has pipelineTriggerRecords`]:
-          (r) => r.json().pipeline_trigger_records !== undefined,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response has next_page_token`]:
-          (r) => r.json().total_size !== undefined,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response has total_size`]:
-          (r) => r.json().next_page_token !== undefined,
+          (r) => r.json().pipelineTriggerRecords !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response has nextPageToken`]:
+          (r) => r.json().totalSize !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers response has totalSize`]:
+          (r) => r.json().nextPageToken !== undefined,
       }
     )
     check(
@@ -305,11 +305,11 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response pipelineTriggerRecords length is 0`]:
-          (r) => r.json().pipeline_trigger_records.length === 0,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response next_page_token is empty`]:
-          (r) => r.json().next_page_token === emptyPipelineTriggerRecordResponse.nextPageToken,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response total_size is 0`]:
-          (r) => r.json().total_size === emptyPipelineTriggerRecordResponse.totalSize,
+          (r) => r.json().pipelineTriggerRecords.length === 0,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response nextPageToken is empty`]:
+          (r) => r.json().nextPageToken === emptyPipelineTriggerRecordResponse.nextPageToken,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/triggers with filter response totalSize is 0`]:
+          (r) => r.json().totalSize === emptyPipelineTriggerRecordResponse.totalSize,
       }
     )
   })
@@ -334,11 +334,11 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has pipelineTriggerTableRecords`]:
-          (r) => r.json().pipeline_trigger_table_records !== undefined,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has next_page_token`]:
-          (r) => r.json().total_size !== undefined,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has total_size`]:
-          (r) => r.json().next_page_token !== undefined,
+          (r) => r.json().pipelineTriggerTableRecords !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has nextPageToken`]:
+          (r) => r.json().totalSize !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has totalSize`]:
+          (r) => r.json().nextPageToken !== undefined,
       }
     )
     check(
@@ -352,11 +352,11 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response pipelineTriggerTableRecords length is 0`]:
-          (r) => r.json().pipeline_trigger_table_records.length === 0,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response next_page_token is empty`]:
-          (r) => r.json().next_page_token === emptyPipelineTriggerTableRecordResponse.nextPageToken,
-        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response total_size is 0`]:
-          (r) => r.json().total_size === emptyPipelineTriggerTableRecordResponse.totalSize,
+          (r) => r.json().pipelineTriggerTableRecords.length === 0,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response nextPageToken is empty`]:
+          (r) => r.json().nextPageToken === emptyPipelineTriggerTableRecordResponse.nextPageToken,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response totalSize is 0`]:
+          (r) => r.json().totalSize === emptyPipelineTriggerTableRecordResponse.totalSize,
       }
     )
   })
@@ -375,7 +375,7 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts response has pipelineTriggerRecords`]:
-          (r) => r.json().pipeline_trigger_chart_records !== undefined,
+          (r) => r.json().pipelineTriggerChartRecords !== undefined,
       }
     )
     check(
@@ -389,7 +389,7 @@ export function CheckPublicMetrics(header) {
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts with filter response status is 200`]:
           (r) => r.status === 200,
         [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts with filter response pipelineTriggerRecords length is 0`]:
-          (r) => r.json().pipeline_trigger_chart_records.length === 0,
+          (r) => r.json().pipelineTriggerChartRecords.length === 0,
       }
     )
   })

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -27,7 +27,7 @@ export function setup() {
 
   return {
     "headers": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     }
   }
 }


### PR DESCRIPTION
Because

- Currently, our API HTTP request and response bodies are a mix of camelCase and snake_case, which is not consistent.

This commit

- Uses camelCase for HTTP bodies.