### PR TITLE
chore(mgmt): make ApiToken last_use_time return null for zero value

### DIFF
--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -428,7 +428,12 @@ func (s *service) DBToken2PBToken(ctx context.Context, dbToken *datamodel.Token)
 		Expiration:  &mgmtPB.ApiToken_ExpireTime{ExpireTime: timestamppb.New(dbToken.ExpireTime)},
 		CreateTime:  timestamppb.New(dbToken.Base.CreateTime),
 		UpdateTime:  timestamppb.New(dbToken.Base.UpdateTime),
-		LastUseTime: timestamppb.New(dbToken.LastUseTime),
+		LastUseTime: func() *timestamppb.Timestamp {
+			if dbToken.LastUseTime.IsZero() {
+				return nil
+			}
+			return timestamppb.New(dbToken.LastUseTime)
+		}(),
 	}, nil
 }
 


### PR DESCRIPTION
Because

- Currently, if the `last_use_time` is zero, the API returns a zero date, which is confusing.

This commit

- Makes `last_use_time` in `ApiToken` return null for zero value.