### PR TITLE
feat: add script to create `preset` namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604160543-3126f88c532e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240626092719-eaf7fa6dbcce
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1090,8 +1090,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604160543-3126f88c532e h1:ihMq6jTeVHxE3E+pvpp2/Xo9Oh0TXpeJ69FsLB6znqc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240604160543-3126f88c532e/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240626092719-eaf7fa6dbcce h1:MzatUjXyl2apW/tWlBimSRJ4bASSKMCWmI1UQ9EqzC8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240626092719-eaf7fa6dbcce/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -13,6 +13,10 @@ const DefaultJwtExpiration = 86400 * 7
 const DefaultJwtIssuer = "http://localhost:8080"
 const DefaultJwtAudience = "http://localhost:8080"
 
+const PresetOrgID = "preset"
+const PresetOrgUID = "63196cec-1c95-49e8-9bf6-9f9497a15f72"
+const PresetOrgDisplayName = "Preset"
+
 // HeaderUserIDKey is the header key for the User ID
 const HeaderUserIDKey = "Instill-User-Id"
 

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/instill-ai/x/sterr"
 
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	checkfield "github.com/instill-ai/x/checkfield"
 )
 
 const defaultPageSize = int32(10)
@@ -160,4 +161,31 @@ func (h *PrivateHandler) LookUpOrganizationAdmin(ctx context.Context, req *mgmtP
 		Organization: pbOrganization,
 	}
 	return &resp, nil
+}
+
+func (h *PrivateHandler) CheckNamespaceAdmin(ctx context.Context, req *mgmtPB.CheckNamespaceAdminRequest) (*mgmtPB.CheckNamespaceAdminResponse, error) {
+
+	err := checkfield.CheckResourceID(req.GetId())
+	if err != nil {
+		return nil, ErrResourceID
+	}
+
+	user, err := h.Service.GetUserAdmin(ctx, req.GetId())
+	if err == nil {
+		return &mgmtPB.CheckNamespaceAdminResponse{
+			Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_USER,
+			Uid:  *user.Uid,
+		}, nil
+	}
+	org, err := h.Service.GetOrganizationAdmin(ctx, req.GetId())
+	if err == nil {
+		return &mgmtPB.CheckNamespaceAdminResponse{
+			Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_ORGANIZATION,
+			Uid:  org.Uid,
+		}, nil
+	}
+
+	return &mgmtPB.CheckNamespaceAdminResponse{
+		Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_AVAILABLE,
+	}, nil
 }


### PR DESCRIPTION
Because

- In Instill Core, we'll provide a "preset" namespace for storing preset resources, such as preset pipelines.

This commit

- Adds script to create the "preset" namespace.
