### PR TITLE
feat: add private endpoint `CheckNamespaceByUIDAdmin`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1090,8 +1090,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885 h1:z8/nJ9DqF+qc/uPsd0+Bg2gD4+6/SR+HT/mkAu0hsAE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc h1:Lqeu0CKe/XZiK8RxHQXcBGKqtz+e3ITpPkyq1WwQvOQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/privatehandler.go
+++ b/pkg/handler/privatehandler.go
@@ -168,6 +168,9 @@ func (h *PrivateHandler) CheckNamespaceAdmin(ctx context.Context, req *mgmtPB.Ch
 		return &mgmtPB.CheckNamespaceAdminResponse{
 			Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_USER,
 			Uid:  *user.Uid,
+			Owner: &mgmtPB.CheckNamespaceAdminResponse_User{
+				User: user,
+			},
 		}, nil
 	}
 	org, err := h.Service.GetOrganizationAdmin(ctx, req.GetId())
@@ -175,10 +178,41 @@ func (h *PrivateHandler) CheckNamespaceAdmin(ctx context.Context, req *mgmtPB.Ch
 		return &mgmtPB.CheckNamespaceAdminResponse{
 			Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_ORGANIZATION,
 			Uid:  org.Uid,
+			Owner: &mgmtPB.CheckNamespaceAdminResponse_Organization{
+				Organization: org,
+			},
 		}, nil
 	}
 
 	return &mgmtPB.CheckNamespaceAdminResponse{
 		Type: mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_AVAILABLE,
+	}, nil
+}
+
+func (h *PrivateHandler) CheckNamespaceByUIDAdmin(ctx context.Context, req *mgmtPB.CheckNamespaceByUIDAdminRequest) (*mgmtPB.CheckNamespaceByUIDAdminResponse, error) {
+
+	user, err := h.Service.GetUserAdmin(ctx, req.GetUid())
+	if err == nil {
+		return &mgmtPB.CheckNamespaceByUIDAdminResponse{
+			Type: mgmtPB.CheckNamespaceByUIDAdminResponse_NAMESPACE_USER,
+			Id:   user.Id,
+			Owner: &mgmtPB.CheckNamespaceByUIDAdminResponse_User{
+				User: user,
+			},
+		}, nil
+	}
+	org, err := h.Service.GetOrganizationAdmin(ctx, req.GetUid())
+	if err == nil {
+		return &mgmtPB.CheckNamespaceByUIDAdminResponse{
+			Type: mgmtPB.CheckNamespaceByUIDAdminResponse_NAMESPACE_ORGANIZATION,
+			Id:   org.Id,
+			Owner: &mgmtPB.CheckNamespaceByUIDAdminResponse_Organization{
+				Organization: org,
+			},
+		}, nil
+	}
+
+	return &mgmtPB.CheckNamespaceByUIDAdminResponse{
+		Type: mgmtPB.CheckNamespaceByUIDAdminResponse_NAMESPACE_AVAILABLE,
 	}, nil
 }


### PR DESCRIPTION
Because

- We want to provide an internal helper endpoint to allow other backends to easily query namespace information.

This commit

- Adds a private endpoint `CheckNamespaceByUIDAdmin`