### PR TITLE
feat: unify pipeline trigger chart endpoint with credit chart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725140016-18f3ff64c952
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1090,8 +1090,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc h1:Lqeu0CKe/XZiK8RxHQXcBGKqtz+e3ITpPkyq1WwQvOQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504 h1:xzwR0C4g54tQFOPsPnANbMfpdUj9SJtVs81nBf2HDrE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/go.sum
+++ b/go.sum
@@ -1090,8 +1090,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504 h1:xzwR0C4g54tQFOPsPnANbMfpdUj9SJtVs81nBf2HDrE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725140016-18f3ff64c952 h1:gtc9vYwc5sEWIs5H1bdu0vx5IgZb0CKcvBa0VWtU8VE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725140016-18f3ff64c952/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,21 @@
+// package errors contains domain errors that different layers can use to add
+// meaning to an error and that middleware can transform to a status code or
+// retry policy. This is implemented as a separate package in order to avoid
+// cycle import errors.
+//
+// TODO jvallesm: when transforming domain errors to response codes, the
+// middleware package should eventually use these errors only.
+package errors
+
+import (
+	"fmt"
+)
+
+var (
+	// ErrInvalidArgument is used when the provided argument is incorrect (e.g.
+	// format, reserved).
+	ErrInvalidArgument = fmt.Errorf("invalid argument")
+	// ErrUnauthorized is used when a request can't be performed due to
+	// insufficient permissions.
+	ErrUnauthorized = fmt.Errorf("unauthorized")
+)

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -858,6 +858,39 @@ func (h *PublicHandler) ValidateToken(ctx context.Context, req *mgmtPB.ValidateT
 	return &mgmtPB.ValidateTokenResponse{UserUid: userUID}, nil
 }
 
+// ListPipelineTriggerChartRecords returns a timeline of a requester's pipeline
+// trigger count.
+func (h *PublicHandler) ListPipelineTriggerChartRecords(ctx context.Context, req *mgmtPB.ListPipelineTriggerChartRecordsRequest) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error) {
+	eventName := "ListPipelineTriggerChartRecords"
+	ctx, span := tracer.Start(ctx, eventName,
+		trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	logUUID, _ := uuid.NewV4()
+	logger, _ := logger.GetZapLogger(ctx)
+
+	ctxUserUID, err := h.Service.ExtractCtxUser(ctx, false)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	resp, err := h.Service.ListPipelineTriggerChartRecords(ctx, req, ctxUserUID)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, fmt.Errorf("fetching credit chart records: %w", err)
+	}
+
+	logger.Info(string(custom_otel.NewLogMessage(
+		span,
+		logUUID.String(),
+		ctxUserUID,
+		eventName,
+	)))
+
+	return resp, nil
+}
+
 func (h *PublicHandler) ListUserMemberships(ctx context.Context, req *mgmtPB.ListUserMembershipsRequest) (*mgmtPB.ListUserMembershipsResponse, error) {
 
 	eventName := "ListUserMemberships"

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -858,6 +858,39 @@ func (h *PublicHandler) ValidateToken(ctx context.Context, req *mgmtPB.ValidateT
 	return &mgmtPB.ValidateTokenResponse{UserUid: userUID}, nil
 }
 
+// GetPipelineTriggerCount returns the pipeline trigger count of a given
+// requester within a timespan.  Results are grouped by trigger status.
+func (h *PublicHandler) GetPipelineTriggerCount(ctx context.Context, req *mgmtPB.GetPipelineTriggerCountRequest) (*mgmtPB.GetPipelineTriggerCountResponse, error) {
+	eventName := "GetPipelineTriggerCount"
+	ctx, span := tracer.Start(ctx, eventName,
+		trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	logUUID, _ := uuid.NewV4()
+	logger, _ := logger.GetZapLogger(ctx)
+
+	ctxUserUID, err := h.Service.ExtractCtxUser(ctx, false)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	resp, err := h.Service.GetPipelineTriggerCount(ctx, req, ctxUserUID)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, fmt.Errorf("fetching credit chart records: %w", err)
+	}
+
+	logger.Info(string(custom_otel.NewLogMessage(
+		span,
+		logUUID.String(),
+		ctxUserUID,
+		eventName,
+	)))
+
+	return resp, nil
+}
+
 // ListPipelineTriggerChartRecords returns a timeline of a requester's pipeline
 // trigger count.
 func (h *PublicHandler) ListPipelineTriggerChartRecords(ctx context.Context, req *mgmtPB.ListPipelineTriggerChartRecordsRequest) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error) {

--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -11,17 +11,20 @@ import (
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpcrecovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+
 	"github.com/instill-ai/mgmt-backend/pkg/acl"
 	"github.com/instill-ai/mgmt-backend/pkg/handler"
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 	"github.com/instill-ai/mgmt-backend/pkg/service"
+
+	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
 )
 
 // RecoveryInterceptor - panic handler
-func RecoveryInterceptorOpt() grpc_recovery.Option {
-	return grpc_recovery.WithRecoveryHandler(func(p interface{}) (err error) {
+func RecoveryInterceptorOpt() grpcrecovery.Option {
+	return grpcrecovery.WithRecoveryHandler(func(p interface{}) (err error) {
 		return status.Errorf(codes.Unknown, "panic triggered: %v", p)
 	})
 }
@@ -47,7 +50,7 @@ func StreamAppendMetadataInterceptor(srv interface{}, stream grpc.ServerStream, 
 	}
 
 	newCtx := metadata.NewIncomingContext(stream.Context(), md)
-	wrapped := grpc_middleware.WrapServerStream(stream)
+	wrapped := grpcmiddleware.WrapServerStream(stream)
 	wrapped.WrappedContext = newCtx
 
 	err := handler(srv, wrapped)
@@ -64,21 +67,23 @@ func InjectErrCode(err error) error {
 
 	case
 		errors.Is(err, gorm.ErrDuplicatedKey):
+
 		return status.Error(codes.AlreadyExists, err.Error())
 	case
 		errors.Is(err, gorm.ErrRecordNotFound):
-		return status.Error(codes.NotFound, err.Error())
 
+		return status.Error(codes.NotFound, err.Error())
 	case
 		errors.Is(err, repository.ErrNoDataDeleted):
-		return status.Error(codes.NotFound, err.Error())
 
+		return status.Error(codes.NotFound, err.Error())
 	case
 		errors.Is(err, repository.ErrOwnerTypeNotMatch),
 		errors.Is(err, repository.ErrPageTokenDecode):
-		return status.Error(codes.InvalidArgument, err.Error())
 
+		return status.Error(codes.InvalidArgument, err.Error())
 	case
+		errors.Is(err, errdomain.ErrInvalidArgument),
 		errors.Is(err, service.ErrCanNotRemoveOwnerFromOrganization),
 		errors.Is(err, service.ErrCanNotSetAnotherOwner),
 		errors.Is(err, service.ErrInvalidRole),
@@ -86,24 +91,24 @@ func InjectErrCode(err error) error {
 		errors.Is(err, service.ErrStateCanOnlyBeActive),
 		errors.Is(err, service.ErrPasswordNotMatch),
 		errors.Is(err, service.ErrInvalidOwnerNamespace):
+
 		return status.Error(codes.InvalidArgument, err.Error())
-
 	case
-		errors.Is(err, service.ErrNoPermission):
-		return status.Error(codes.PermissionDenied, err.Error())
+		errors.Is(err, errdomain.ErrUnauthorized):
 
+		return status.Error(codes.PermissionDenied, err.Error())
 	case
 		errors.Is(err, service.ErrUnauthenticated):
-		return status.Error(codes.Unauthenticated, err.Error())
 
+		return status.Error(codes.Unauthenticated, err.Error())
 	case
 		errors.Is(err, acl.ErrMembershipNotFound):
-		return status.Error(codes.NotFound, err.Error())
 
+		return status.Error(codes.NotFound, err.Error())
 	case
 		errors.Is(err, bcrypt.ErrMismatchedHashAndPassword):
-		return status.Error(codes.InvalidArgument, err.Error())
 
+		return status.Error(codes.InvalidArgument, err.Error())
 	case
 		errors.Is(err, handler.ErrCheckUpdateImmutableFields),
 		errors.Is(err, handler.ErrCheckOutputOnlyFields),
@@ -111,8 +116,8 @@ func InjectErrCode(err error) error {
 		errors.Is(err, handler.ErrFieldMask),
 		errors.Is(err, handler.ErrResourceID),
 		errors.Is(err, handler.ErrUpdateMask):
-		return status.Error(codes.InvalidArgument, err.Error())
 
+		return status.Error(codes.InvalidArgument, err.Error())
 	default:
 		return err
 	}

--- a/pkg/repository/influx.go
+++ b/pkg/repository/influx.go
@@ -2,26 +2,29 @@ package repository
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/log"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	client "github.com/influxdata/influxdb-client-go/v2"
 
 	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
+
+	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
+	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
-
-// DefaultPageSize is the default pagination page size when page size is not assigned
-const DefaultPageSize = 100
-
-// MaxPageSize is the maximum pagination page size if the assigned value is over this number
-const MaxPageSize = 1000
 
 // InfluxDB interface
 type InfluxDB interface {
+	ListPipelineTriggerChartRecords(ctx context.Context, p ListPipelineTriggerChartRecordsParams) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error)
+
 	Bucket() string
 	QueryAPI() api.QueryAPI
 	Close()
@@ -94,4 +97,95 @@ func (i *influxDB) QueryAPI() api.QueryAPI {
 // Bucket returns the InfluxDB bucket the repository reads from.
 func (i *influxDB) Bucket() string {
 	return i.bucket
+}
+
+const qPipelineTriggerChartRecords = `
+from(bucket: "%s")
+	|> range(start: %s, stop: %s)
+	|> filter(fn: (r) => r._measurement == "pipeline.trigger" and r.requester_uid == "%s")
+	|> filter(fn: (r) => r._field == "trigger_time")
+	|> group(columns:["requester_uid"])
+	|> aggregateWindow(every: %s, column:"_value", fn: count, createEmpty: true, offset: %s)
+`
+
+// ListPipelineTriggerChartRecordsParams contains the required information to
+// query the pipeline triggers of a namespace.
+// TODO jvallesm: this should be defined in the service package for better
+// decoupling. At the moment this implies breaking an import cycle with many
+// dependencies.
+type ListPipelineTriggerChartRecordsParams struct {
+	NamespaceID       string
+	NamespaceUID      uuid.UUID
+	AggregationWindow time.Duration
+	Start             time.Time
+	Stop              time.Time
+}
+
+func (i *influxDB) ListPipelineTriggerChartRecords(
+	ctx context.Context,
+	p ListPipelineTriggerChartRecordsParams,
+) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error) {
+	l, _ := logger.GetZapLogger(ctx)
+	l = l.With(zap.Reflect("triggerChartParams", p))
+
+	query := fmt.Sprintf(
+		qPipelineTriggerChartRecords,
+		i.Bucket(),
+		p.Start.Format(time.RFC3339Nano),
+		p.Stop.Format(time.RFC3339Nano),
+		p.NamespaceUID.String(),
+		p.AggregationWindow,
+		AggregationWindowOffset(p.Start).String(),
+	)
+	result, err := i.QueryAPI().Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("%w: querying data from InfluxDB: %w", errdomain.ErrInvalidArgument, err)
+	}
+
+	defer result.Close()
+
+	record := &mgmtpb.PipelineTriggerChartRecord{
+		NamespaceId:   p.NamespaceID,
+		TimeBuckets:   []*timestamppb.Timestamp{},
+		TriggerCounts: []int32{},
+	}
+
+	// Until filtering and grouping are implemented, we'll only have one record
+	// (total triggers by requester).
+	records := []*mgmtpb.PipelineTriggerChartRecord{record}
+
+	for result.Next() {
+		t := result.Record().Time()
+		record.TimeBuckets = append(record.TimeBuckets, timestamppb.New(t))
+
+		v, match := result.Record().Value().(int64)
+		if !match {
+			l.With(zap.Time("_time", result.Record().Time())).
+				Error("Missing count on pipeline trigger chart record.")
+		}
+
+		record.TriggerCounts = append(record.TriggerCounts, int32(v))
+	}
+
+	if result.Err() != nil {
+		return nil, fmt.Errorf("collecting information from pipeline trigger chart records: %w", err)
+	}
+
+	if result.Record() == nil {
+		return nil, nil
+	}
+
+	return &mgmtpb.ListPipelineTriggerChartRecordsResponse{
+		PipelineTriggerChartRecords: records,
+	}, nil
+}
+
+// AggregationWindowOffset computes the offset to apply to InfluxDB's
+// aggregateWindow function when aggregating by day. This function computes
+// windows independently, starting from the Unix epoch, rather than from the
+// provided time range start. This function computes the offset to shift the
+// windows correctly.
+func AggregationWindowOffset(t time.Time) time.Duration {
+	startOfDay := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	return t.Sub(startOfDay)
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -21,6 +21,16 @@ import (
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
+const (
+	// DefaultPageSize is the default pagination page size when page size is
+	// not assigned
+	DefaultPageSize = 100
+
+	// MaxPageSize is the maximum pagination page size if the assigned value is
+	// over this number
+	MaxPageSize = 1000
+)
+
 type CtxKey string
 
 // UserUIDCtxKey must be present in the context in order to pin a user to the

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -6,12 +6,14 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-redis/redismock/v9"
+	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/mgmt-backend/config"
@@ -61,4 +63,90 @@ func TestRepository_CreateUser(t *testing.T) {
 	c.Check(err, qt.IsNil)
 	c.Check(got.CreateTime.After(t0), qt.IsTrue)
 	c.Check(got.UpdateTime.After(t0), qt.IsTrue)
+}
+
+func TestRepository_GetOwner(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	cache, _ := redismock.NewClientMock()
+	tx := db.Begin()
+	c.Cleanup(func() { tx.Rollback() })
+
+	repo := NewRepository(tx, cache)
+
+	user := &datamodel.Owner{
+		ID:    "piano-wombat",
+		Email: "piano@wombats.com",
+		OwnerType: sql.NullString{
+			String: "user",
+			Valid:  true,
+		},
+	}
+	org := &datamodel.Owner{
+		ID:    "the-wombies",
+		Email: "org@wombats.com",
+		OwnerType: sql.NullString{
+			String: "organization",
+			Valid:  true,
+		},
+	}
+
+	user.UID, org.UID = uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4())
+
+	err := repo.CreateUser(ctx, user)
+	c.Check(err, qt.IsNil)
+
+	err = repo.CreateOrganization(ctx, org)
+	c.Check(err, qt.IsNil)
+
+	c.Run("nok - get with wrong type", func(c *qt.C) {
+		_, err := repo.GetUser(ctx, org.ID, false)
+		c.Check(errors.Is(err, gorm.ErrRecordNotFound), qt.IsTrue, qt.Commentf(err.Error()))
+
+		_, err = repo.GetUserByUID(ctx, org.UID)
+		c.Check(errors.Is(err, gorm.ErrRecordNotFound), qt.IsTrue, qt.Commentf(err.Error()))
+
+		_, err = repo.GetOrganization(ctx, user.ID, false)
+		c.Check(errors.Is(err, gorm.ErrRecordNotFound), qt.IsTrue, qt.Commentf(err.Error()))
+
+		_, err = repo.GetOrganizationByUID(ctx, user.UID)
+		c.Check(errors.Is(err, gorm.ErrRecordNotFound), qt.IsTrue, qt.Commentf(err.Error()))
+	})
+
+	c.Run("ok - get with type", func(c *qt.C) {
+		gotUser, err := repo.GetUser(ctx, user.ID, false)
+		c.Check(err, qt.IsNil)
+		c.Check(gotUser.UID, qt.Equals, user.UID)
+
+		gotUser, err = repo.GetUserByUID(ctx, user.UID)
+		c.Check(err, qt.IsNil)
+		c.Check(gotUser.ID, qt.Equals, user.ID)
+
+		gotOrg, err := repo.GetOrganization(ctx, org.ID, false)
+		c.Check(err, qt.IsNil)
+		c.Check(gotOrg.UID, qt.Equals, org.UID)
+
+		gotOrg, err = repo.GetOrganizationByUID(ctx, org.UID)
+		c.Check(err, qt.IsNil)
+		c.Check(gotOrg.ID, qt.Equals, org.ID)
+	})
+
+	c.Run("ok - get without type", func(c *qt.C) {
+		gotUser, err := repo.GetOwner(ctx, user.ID, false)
+		c.Check(err, qt.IsNil)
+		c.Check(gotUser.UID, qt.Equals, user.UID)
+
+		gotUser, err = repo.GetOwnerByUID(ctx, user.UID)
+		c.Check(err, qt.IsNil)
+		c.Check(gotUser.ID, qt.Equals, user.ID)
+
+		gotOrg, err := repo.GetOwner(ctx, org.ID, false)
+		c.Check(err, qt.IsNil)
+		c.Check(gotOrg.UID, qt.Equals, org.UID)
+
+		gotOrg, err = repo.GetOwnerByUID(ctx, org.UID)
+		c.Check(err, qt.IsNil)
+		c.Check(gotOrg.ID, qt.Equals, org.ID)
+	})
 }

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -2,7 +2,6 @@ package service
 
 import "errors"
 
-var ErrNoPermission = errors.New("no permission")
 var ErrUnauthenticated = errors.New("unauthenticated")
 var ErrInvalidTokenTTL = errors.New("invalid token ttl")
 var ErrInvalidRole = errors.New("invalid role")

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -91,15 +91,7 @@ func (s *service) ListPipelineTriggerChartRecords(
 // GrantedNamespaceUID returns the UID of a namespace, provided the
 // authenticated user has access to it.
 func (s *service) GrantedNamespaceUID(ctx context.Context, namespaceID string, authenticatedUserUID uuid.UUID) (uuid.UUID, error) {
-	owner, err := s.repository.GetUser(ctx, namespaceID, false)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		// TODO jvallesm: with the namespace refactor we should have a
-		// GetNamespace method that will allow us to fetch the owner UID
-		// without knowing the owner type. For convenience, we try user first
-		// and fall back to organization.
-		owner, err = s.repository.GetOrganization(ctx, namespaceID, false)
-	}
-
+	owner, err := s.repository.GetOwner(ctx, namespaceID, false)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			err = errdomain.ErrUnauthorized

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -2,12 +2,102 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
 
-	"google.golang.org/grpc/metadata"
+	"gorm.io/gorm"
+
+	"github.com/gofrs/uuid"
+	"github.com/instill-ai/mgmt-backend/pkg/acl"
+	"github.com/instill-ai/mgmt-backend/pkg/repository"
+
+	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
+	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
-func InjectOwnerToContext(ctx context.Context, uid string) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "instill-auth-type", "user")
-	ctx = metadata.AppendToOutgoingContext(ctx, "instill-user-uid", uid)
-	return ctx
+func (s *service) ListPipelineTriggerChartRecords(
+	ctx context.Context,
+	req *mgmtpb.ListPipelineTriggerChartRecordsRequest,
+	ctxUserUID uuid.UUID,
+) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error) {
+	nsUID, err := s.GrantedNamespaceUID(ctx, req.GetNamespaceId(), ctxUserUID)
+	if err != nil {
+		return nil, fmt.Errorf("checking user permissions: %w", err)
+	}
+
+	now := time.Now().UTC()
+	p := repository.ListPipelineTriggerChartRecordsParams{
+		NamespaceID:  req.GetNamespaceId(),
+		NamespaceUID: nsUID,
+
+		// Default values
+		AggregationWindow: 1 * time.Hour,
+		Start:             time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()),
+		Stop:              now,
+	}
+
+	if req.GetAggregationWindow() != "" {
+		window, err := time.ParseDuration(req.GetAggregationWindow())
+		if err != nil {
+			return nil, fmt.Errorf("%w: extracting duration from aggregation window: %w", errdomain.ErrInvalidArgument, err)
+		}
+
+		p.AggregationWindow = window
+	}
+
+	if req.GetStart() != nil {
+		p.Start = req.GetStart().AsTime()
+	}
+
+	if req.GetStop() != nil {
+		p.Stop = req.GetStop().AsTime()
+	}
+
+	return s.influxDB.ListPipelineTriggerChartRecords(ctx, p)
+}
+
+// GrantedNamespaceUID returns the UID of a namespace, provided the
+// authenticated user has access to it.
+func (s *service) GrantedNamespaceUID(ctx context.Context, namespaceID string, authenticatedUserUID uuid.UUID) (uuid.UUID, error) {
+	owner, err := s.repository.GetUser(ctx, namespaceID, false)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		// TODO jvallesm: with the namespace refactor we should have a
+		// GetNamespace method that will allow us to fetch the owner UID
+		// without knowing the owner type. For convenience, we try user first
+		// and fall back to organization.
+		owner, err = s.repository.GetOrganization(ctx, namespaceID, false)
+	}
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = errdomain.ErrUnauthorized
+		}
+
+		return uuid.Nil, fmt.Errorf("fetching namespace UID: %w", err)
+	}
+
+	nsUID := owner.UID
+	if nsUID == authenticatedUserUID {
+		// The authenticated user always has access to their own namespace.
+		return nsUID, nil
+	}
+
+	// The user is requesting information about other namespace: only
+	// organizations that the user is a member of are allowed.
+	role, err := s.GetACLClient().GetOrganizationUserMembership(ctx, nsUID, authenticatedUserUID)
+	if err != nil {
+		if errors.Is(err, acl.ErrMembershipNotFound) {
+			err = errdomain.ErrUnauthorized
+		}
+
+		return uuid.Nil, fmt.Errorf("fetching organization membership: %w", err)
+	}
+
+	if strings.HasPrefix(role, "pending") {
+		return uuid.Nil, fmt.Errorf("invalid permission role: %w", errdomain.ErrUnauthorized)
+	}
+
+	return nsUID, nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -70,6 +70,7 @@ type Service interface {
 	CheckUserPassword(ctx context.Context, uid uuid.UUID, password string) error
 	UpdateUserPassword(ctx context.Context, uid uuid.UUID, newPassword string) error
 
+	GetPipelineTriggerCount(_ context.Context, _ *mgmtPB.GetPipelineTriggerCountRequest, ctxUserUID uuid.UUID) (*mgmtPB.GetPipelineTriggerCountResponse, error)
 	ListPipelineTriggerChartRecords(_ context.Context, _ *mgmtPB.ListPipelineTriggerChartRecordsRequest, ctxUserUID uuid.UUID) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error)
 
 	DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*mgmtPB.User, error)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.einride.tech/aip/filtering"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/instill-ai/mgmt-backend/internal/resource"
 	"github.com/instill-ai/mgmt-backend/pkg/acl"
@@ -17,6 +18,7 @@ import (
 	"github.com/instill-ai/mgmt-backend/pkg/datamodel"
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 
+	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -68,6 +70,8 @@ type Service interface {
 	CheckUserPassword(ctx context.Context, uid uuid.UUID, password string) error
 	UpdateUserPassword(ctx context.Context, uid uuid.UUID, newPassword string) error
 
+	ListPipelineTriggerChartRecords(_ context.Context, _ *mgmtPB.ListPipelineTriggerChartRecordsRequest, ctxUserUID uuid.UUID) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error)
+
 	DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*mgmtPB.User, error)
 	DBUsers2PBUsers(ctx context.Context, dbUsers []*datamodel.Owner) ([]*mgmtPB.User, error)
 	PBAuthenticatedUser2DBUser(ctx context.Context, pbUser *mgmtPB.AuthenticatedUser) (*datamodel.Owner, error)
@@ -80,6 +84,8 @@ type Service interface {
 	GetRedisClient() *redis.Client
 	GetInfluxClient() repository.InfluxDB
 	GetACLClient() *acl.ACLClient
+
+	GrantedNamespaceUID(_ context.Context, namespaceID string, authenticatedUserUID uuid.UUID) (uuid.UUID, error)
 }
 
 type service struct {
@@ -389,7 +395,7 @@ func (s *service) UpdateOrganization(ctx context.Context, ctxUserUID uuid.UUID, 
 		return nil, err
 	}
 	if !canUpdateOrganization {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	// Update the user
@@ -424,7 +430,7 @@ func (s *service) DeleteOrganization(ctx context.Context, ctxUserUID uuid.UUID, 
 		return err
 	}
 	if !canDeleteOrganization {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 
 	err = s.deleteOrganizationFromCacheByID(ctx, id)
@@ -683,7 +689,7 @@ func (s *service) ListUserMemberships(ctx context.Context, ctxUserUID uuid.UUID,
 		return nil, fmt.Errorf("users/%s: %w", userID, err)
 	}
 	if ctxUserUID != user.UID {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	orgRelations, err := s.aclClient.GetUserOrganizations(ctx, user.UID)
@@ -737,7 +743,7 @@ func (s *service) GetUserMembership(ctx context.Context, ctxUserUID uuid.UUID, u
 		return nil, fmt.Errorf("users/%s: %w", userID, err)
 	}
 	if ctxUserUID != user.UID {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 	org, err := s.repository.GetOrganization(ctx, orgID, false)
 	if err != nil {
@@ -786,7 +792,7 @@ func (s *service) UpdateUserMembership(ctx context.Context, ctxUserUID uuid.UUID
 		return nil, fmt.Errorf("users/%s: %w", userID, err)
 	}
 	if ctxUserUID != user.UID {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 	org, err := s.repository.GetOrganization(ctx, orgID, false)
 	if err != nil {
@@ -844,7 +850,7 @@ func (s *service) DeleteUserMembership(ctx context.Context, ctxUserUID uuid.UUID
 		return fmt.Errorf("users/%s: %w", userID, err)
 	}
 	if ctxUserUID != user.UID {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 	org, err := s.repository.GetOrganization(ctx, orgID, false)
 	if err != nil {
@@ -871,7 +877,7 @@ func (s *service) ListOrganizationMemberships(ctx context.Context, ctxUserUID uu
 		return nil, err
 	}
 	if !canGetMembership {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	canSetMembership, err := s.aclClient.CheckOrganizationUserMembership(ctx, org.UID, ctxUserUID, "can_set_membership")
@@ -941,7 +947,7 @@ func (s *service) GetOrganizationMembership(ctx context.Context, ctxUserUID uuid
 		return nil, err
 	}
 	if !canGetMembership {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 	canSetMembership, err := s.aclClient.CheckOrganizationUserMembership(ctx, org.UID, ctxUserUID, "can_set_membership")
 	if err != nil {
@@ -970,7 +976,7 @@ func (s *service) GetOrganizationMembership(ctx context.Context, ctxUserUID uuid
 
 	if state == mgmtPB.MembershipState_MEMBERSHIP_STATE_PENDING && ctxUserUID != uuid.FromStringOrNil(*pbUser.Uid) {
 		if !canSetMembership {
-			return nil, ErrNoPermission
+			return nil, errdomain.ErrUnauthorized
 		}
 	}
 	membership := &mgmtPB.OrganizationMembership{
@@ -1006,7 +1012,7 @@ func (s *service) UpdateOrganizationMembership(ctx context.Context, ctxUserUID u
 		return nil, err
 	}
 	if !canSetMembership {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	if membership.Role == "owner" {
@@ -1079,7 +1085,7 @@ func (s *service) DeleteOrganizationMembership(ctx context.Context, ctxUserUID u
 		return err
 	}
 	if !canRemoveMembership {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 	if canRemoveMembership && ctxUserUID == user.UID {
 		return ErrCanNotRemoveOwnerFromOrganization
@@ -1089,4 +1095,10 @@ func (s *service) DeleteOrganizationMembership(ctx context.Context, ctxUserUID u
 		return err
 	}
 	return nil
+}
+
+func InjectOwnerToContext(ctx context.Context, uid string) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, "instill-auth-type", "user")
+	ctx = metadata.AppendToOutgoingContext(ctx, "instill-user-uid", uid)
+	return ctx
 }


### PR DESCRIPTION
Because

- Pipeline and credit endpoints have different params and schemas.
- Some of the information served by the existing endpoints will be handled by the logging feature.

This commit

- Applies contracts defined in https://github.com/instill-ai/protobufs/pull/387
