### PR TITLE
fix: restore pipeline dashboard enpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240726044326-e2dcf1c317f4
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729070104-1b23ffa897eb
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1090,10 +1090,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725140016-18f3ff64c952 h1:gtc9vYwc5sEWIs5H1bdu0vx5IgZb0CKcvBa0VWtU8VE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725140016-18f3ff64c952/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240726044326-e2dcf1c317f4 h1:LTnrCSgLcgYLQR43NGrAswAQ+XroDAbLEvCMTK//AxU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240726044326-e2dcf1c317f4/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729070104-1b23ffa897eb h1:3NyTWRr4HDB0Hz83Bd66g7s0qCytHOA7oGL6TVe6UsA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240729070104-1b23ffa897eb/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/grpc-public-user.js
+++ b/integration-test/grpc-public-user.js
@@ -239,15 +239,9 @@ export function CheckPublicGetRemainingCredit(header) {
 }
 
 export function CheckPublicMetrics(header) {
-
-  let pipeline_id = randomString(10)
-
-  client.connect(constant.mgmtPublicGRPCHost, {
-    plaintext: true
-  });
-
-
   group(`Management Public API: List Pipeline Trigger Table Records`, () => {
+
+    let pipeline_id = randomString(10)
 
     let emptyPipelineTriggerTableRecordResponse = {
       "pipelineTriggerTableRecords": [],
@@ -255,11 +249,74 @@ export function CheckPublicMetrics(header) {
       "totalSize": 0
     }
 
+    check(
+      http.request(
+        "GET",
+        `${constant.mgmtPublicHost}/metrics/vdp/pipeline/tables`,
+        null,
+        header,
+      ),
+      {
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response status is 200`]:
+          (r) => r.status === 200,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has pipelineTriggerTableRecords`]:
+          (r) => r.json().pipelineTriggerTableRecords !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has nextPageToken`]:
+          (r) => r.json().totalSize !== undefined,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables response has totalSize`]:
+          (r) => r.json().nextPageToken !== undefined,
+      }
+    )
+    check(
+      http.request(
+        "GET",
+        `${constant.mgmtPublicHost}/metrics/vdp/pipeline/tables?filter=pipelineId=%22${pipeline_id}%22`,
+        null,
+        header,
+      ),
+      {
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response status is 200`]:
+          (r) => r.status === 200,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response pipelineTriggerTableRecords length is 0`]:
+          (r) => r.json().pipelineTriggerTableRecords.length === 0,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response nextPageToken is empty`]:
+          (r) => r.json().nextPageToken === emptyPipelineTriggerTableRecordResponse.nextPageToken,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/tables with filter response totalSize is 0`]:
+          (r) => r.json().totalSize === emptyPipelineTriggerTableRecordResponse.totalSize,
+      }
+    )
+  })
+  group(`Management Public API: List Pipeline Trigger Chart Records`, () => {
 
+    let pipeline_id = randomString(10)
 
-  });
-
-
-
-  client.close();
+    check(
+      http.request(
+        "GET",
+        `${constant.mgmtPublicHost}/metrics/vdp/pipeline/charts`,
+        null,
+        header,
+      ),
+      {
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts response status is 200`]:
+          (r) => r.status === 200,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts response has pipelineTriggerRecords`]:
+          (r) => r.json().pipelineTriggerChartRecords !== undefined,
+      }
+    )
+    check(
+      http.request(
+        "GET",
+        `${constant.mgmtPublicHost}/metrics/vdp/pipeline/charts?filter=triggerMode=MODE_SYNC%20AND%20pipelineId=%22${pipeline_id}%22`,
+        null,
+        header,
+      ),
+      {
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts with filter response status is 200`]:
+          (r) => r.status === 200,
+        [`GET /${constant.mgmtVersion}/metrics/vdp/pipeline/charts with filter response pipelineTriggerRecords length is 0`]:
+          (r) => r.json().pipelineTriggerChartRecords.length === 0,
+      }
+    )
+  })
 }

--- a/integration-test/proto/core/mgmt/v1beta/metric.proto
+++ b/integration-test/proto/core/mgmt/v1beta/metric.proto
@@ -32,29 +32,13 @@ enum Status {
 // PipelineTriggerCount represents a pipeline execution count with some
 // aggregation params (e.g. trigger status).
 message PipelineTriggerCount {
-  // Number og triggers
+  // Number of triggers.
   int32 trigger_count = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // This field will be present when results are grouped by trigger status;
+  // This field will be present when results are grouped by trigger status.
   optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
-// pipeline ID.
-message PipelineTriggerTableRecord {
-  // Pipeline ID.
-  string pipeline_id = 1;
-  // Pipeline UUID.
-  string pipeline_uid = 2;
-  // Number of triggers with `STATUS_COMPLETED`.
-  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Number of triggers with `STATUS_ERRORED`.
-  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Version for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release UUID for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
+/*
 // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
 // contains a collection of (timestamp, count) pairs that represent the total
 // pipeline triggers in a given time bucket.
@@ -82,27 +66,22 @@ message PipelineTriggerChartRecord {
   // 9 is reserved for the pipeline release UUID. The server wasn't grouping
   // results by this field.
   reserved 9;
-  // Trigger requester ID, e.g. `users/specialist-wombat`.
-  string requester = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The ID of the namespace that requested the pipeline triggers.
+  string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
+*/
 
 // GetPipelineTriggerCountRequest represents a request to fetch the trigger
 // count of a requester over a time period.
 message GetPipelineTriggerCountRequest {
-  // The ID of the pipeline trigger requester.
-  // Format: `{[users|organizations]}/{id}`.
-  string requester = 1 [(google.api.field_behavior) = REQUIRED];
-  // Aggregation window. The value is a positive duration string, i.e. a
-  // sequence of decimal numbers, each with optional fraction and a unit
-  // suffix, such as "300ms", "1.5h" or "2h45m".
-  // The minimum (and default) window is 1h.
-  optional string aggregation_window = 2;
+  // The ID of the namespace that requested the pipeline triggers.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Beginning of the time range from which the records will be fetched.
   // The default value is the beginning of the current day, in UTC.
-  optional google.protobuf.Timestamp start = 3;
+  optional google.protobuf.Timestamp start = 2;
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
-  optional google.protobuf.Timestamp stop = 4;
+  optional google.protobuf.Timestamp stop = 3;
 }
 
 // GetPipelineTriggerCountResponse contains the trigger count, grouped by
@@ -112,6 +91,7 @@ message GetPipelineTriggerCountResponse {
   repeated PipelineTriggerCount pipeline_trigger_counts = 1;
 }
 
+/*
 // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
 // trigger chart records for a given requester, grouped by time buckets.
 message ListPipelineTriggerChartRecordsRequest {
@@ -124,9 +104,8 @@ message ListPipelineTriggerChartRecordsRequest {
   // only certain pipelines and to group by the pipeline ID.
   reserved 2;
 
-  // The ID of the pipeline trigger requester.
-  // Format: `{[users|organizations]}/{id}`.
-  string requester = 3 [(google.api.field_behavior) = REQUIRED];
+  // The ID of the namespace that requested the pipeline triggers.
+  string namespace_id = 3 [(google.api.field_behavior) = REQUIRED];
   // Aggregation window. The value is a positive duration string, i.e. a
   // sequence of decimal numbers, each with optional fraction and a unit
   // suffix, such as "300ms", "1.5h" or "2h45m".
@@ -149,13 +128,14 @@ message ListPipelineTriggerChartRecordsResponse {
   // ID, trigger mode, final status or other fields.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
 }
+*/
 
 // CreditConsumptionChartRecord represents a timeline of Instill Credit
 // consumption. It contains a collection of (timestamp, amount) pairs that
 // represent the total credit consumption in a given time bucket.
 message CreditConsumptionChartRecord {
-  // Credit owner ID, e.g. `users/chef-wombat`.
-  string credit_owner = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The ID of the namespace that owns the credit.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total credit consumed in each time bucket.
@@ -168,9 +148,8 @@ message CreditConsumptionChartRecord {
 // consumption chart records for a given owner, grouped by time buckets and
 // consumption sources.
 message ListCreditConsumptionChartRecordsRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
-  string owner = 1 [(google.api.field_behavior) = REQUIRED];
+  // The ID of the namespace that owns the credit.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Aggregation window. The value is a positive duration string, i.e. a
   // sequence of decimal numbers, each with optional fraction and a unit
   // suffix, such as "300ms", "1.5h" or "2h45m".
@@ -193,4 +172,89 @@ message ListCreditConsumptionChartRecordsResponse {
   // the request. This won't be returned anymore as we need to aggregate the
   // consumption by source.
   reserved 2;
+}
+
+// Deprecated messages, to be removed with the new dashboard implementation.
+
+// PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID.
+message PipelineTriggerTableRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Number of triggers with `STATUS_COMPLETED`.
+  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Number of triggers with `STATUS_ERRORED`.
+  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListPipelineTriggerTableRecordsRequest represents a request to list the
+// pipeline triggers metrics, aggregated by pipeline ID.
+message ListPipelineTriggerTableRecordsRequest {
+  // The maximum number of results to return. If this parameter is unspecified,
+  // at most 100 pipelines will be returned. The cap value for this parameter
+  // is 1000 (i.e. any value above that will be coerced to 1000).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
+message ListPipelineTriggerTableRecordsResponse {
+  // A list of pipeline trigger tables.
+  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of pipeline trigger records
+  int32 total_size = 3;
+}
+
+// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
+// trigger metrics, aggregated by pipeline ID and time frame.
+message ListPipelineTriggerChartRecordsRequest {
+  // Aggregation window in nanoseconds.
+  int32 aggregation_window = 1;
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListPipelineTriggerChartRecordsResponse {
+  // A list of pipeline trigger records.
+  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID and time frame.
+message PipelineTriggerChartRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Trigger mode.
+  Mode trigger_mode = 3;
+  // Final status.
+  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total computation time duration in each time bucket.
+  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/integration-test/proto/core/mgmt/v1beta/mgmt.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt.proto
@@ -457,6 +457,50 @@ message CheckNamespaceAdminResponse {
   Namespace type = 1;
   // Namespace UID.
   string uid = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
+}
+
+// CheckNamespaceByUIDAdminRequest represents a request to verify if a namespace is
+// available.
+message CheckNamespaceByUIDAdminRequest {
+  // The namespace UID to be checked.
+  string uid = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNamespaceByUIDAdminResponse contains the availability of a namespace or the type
+// of resource that's using it.
+message CheckNamespaceByUIDAdminResponse {
+  // Namespace contains information about the availability of a namespace.
+  enum Namespace {
+    // Unspecified.
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available.
+    NAMESPACE_AVAILABLE = 1;
+    // Namespace belongs to a user.
+    NAMESPACE_USER = 2;
+    // Namespace belongs to an organization.
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved.
+    NAMESPACE_RESERVED = 4;
+  }
+
+  // Namespace type.
+  Namespace type = 1;
+  // Namespace ID.
+  string id = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
 }
 
 // API tokens allow users to make requests to the Instill AI API.
@@ -1075,8 +1119,8 @@ message UserSubscription {
     PLAN_UNSPECIFIED = 0;
     // Free plan.
     PLAN_FREE = 1;
-    // Starter plan.
-    PLAN_STARTER = 2;
+    // Pro plan.
+    PLAN_PRO = 2;
   }
 
   // Plan identifier.
@@ -1091,22 +1135,20 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Unpaid.
-    PLAN_UNPAID = 1;
+    // Free plan.
+    PLAN_FREE = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.
     PLAN_ENTERPRISE = 3;
-    // Team pro plan.
-    PLAN_TEAM_PRO = 4;
   }
 
   // Plan identifier.
   Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
   StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Maximum number of seats allowed.
-  int32 max_seats = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reserved for max_seats
+  reserved 3;
   // Number of used seats within the organization subscription.
   int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_private_service.proto
@@ -61,4 +61,10 @@ service MgmtPrivateService {
   // Returns the availability of a namespace or, alternatively, the type of
   // resource that is using it.
   rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {}
+
+  // Check if a namespace is in use by UID
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespaceByUIDAdmin(CheckNamespaceByUIDAdminRequest) returns (CheckNamespaceByUIDAdminResponse) {}
 }

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
@@ -290,13 +290,26 @@ service MgmtPublicService {
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+    // This endpoint will remain hidden until the new dashboard is implemented
+    // in the frontend. Until then, the server might return empty data.
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline trigger metrics
+  //
+  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
+  // NOTE: This method is deprecated and will be retired soon.
+  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+    option deprecated  = true;
   }
 
   // List pipeline trigger time charts
   //
-  // Returns a timeline of pipline trigger counts for a given requester. The
-  // response will contain one set of records (datapoints), representing the
-  // amount of triggers in a time bucket.
+  // Returns a timeline of pipline trigger counts for the pipelines of a given
+  // owner.
+  // NOTE: This method will soon return the trigger counts of a given requester.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -858,15 +858,15 @@ func (h *PublicHandler) ValidateToken(ctx context.Context, req *mgmtPB.ValidateT
 	return &mgmtPB.ValidateTokenResponse{UserUid: userUID}, nil
 }
 
-// GetPipelineTriggerCount returns the pipeline trigger count of a given
-// requester within a timespan.  Results are grouped by trigger status.
-func (h *PublicHandler) GetPipelineTriggerCount(ctx context.Context, req *mgmtPB.GetPipelineTriggerCountRequest) (*mgmtPB.GetPipelineTriggerCountResponse, error) {
-	eventName := "GetPipelineTriggerCount"
+func (h *PublicHandler) ListPipelineTriggerTableRecords(ctx context.Context, req *mgmtPB.ListPipelineTriggerTableRecordsRequest) (*mgmtPB.ListPipelineTriggerTableRecordsResponse, error) {
+
+	eventName := "ListPipelineTriggerTableRecords"
 	ctx, span := tracer.Start(ctx, eventName,
 		trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
 	logUUID, _ := uuid.NewV4()
+
 	logger, _ := logger.GetZapLogger(ctx)
 
 	ctxUserUID, err := h.Service.ExtractCtxUser(ctx, false)
@@ -874,32 +874,67 @@ func (h *PublicHandler) GetPipelineTriggerCount(ctx context.Context, req *mgmtPB
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-
-	resp, err := h.Service.GetPipelineTriggerCount(ctx, req, ctxUserUID)
+	pbUser, err := h.Service.GetUserByUIDAdmin(ctx, ctxUserUID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
-		return nil, fmt.Errorf("fetching credit chart records: %w", err)
+		return nil, err
+	}
+
+	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
+		filtering.DeclareStandardFunctions(),
+		filtering.DeclareIdent(constant.Start, filtering.TypeTimestamp),
+		filtering.DeclareIdent(constant.Stop, filtering.TypeTimestamp),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.OwnerName), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineUID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineReleaseID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineReleaseUID), filtering.TypeString),
+	}...)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	filter, err := filtering.ParseFilter(req, declarations)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	pipelineTriggerTableRecords, totalSize, nextPageToken, err := h.Service.ListPipelineTriggerTableRecords(ctx, pbUser, int64(req.GetPageSize()), req.GetPageToken(), filter)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	resp := mgmtPB.ListPipelineTriggerTableRecordsResponse{
+		PipelineTriggerTableRecords: pipelineTriggerTableRecords,
+		NextPageToken:               nextPageToken,
+		TotalSize:                   int32(totalSize),
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
 		span,
 		logUUID.String(),
-		ctxUserUID,
+		uuid.FromStringOrNil(*pbUser.Uid),
 		eventName,
+		custom_otel.SetEventResult(fmt.Sprintf("Total records retrieved: %v", totalSize)),
 	)))
 
-	return resp, nil
+	return &resp, nil
 }
 
 // ListPipelineTriggerChartRecords returns a timeline of a requester's pipeline
 // trigger count.
 func (h *PublicHandler) ListPipelineTriggerChartRecords(ctx context.Context, req *mgmtPB.ListPipelineTriggerChartRecordsRequest) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error) {
+
 	eventName := "ListPipelineTriggerChartRecords"
 	ctx, span := tracer.Start(ctx, eventName,
 		trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
 	logUUID, _ := uuid.NewV4()
+
 	logger, _ := logger.GetZapLogger(ctx)
 
 	ctxUserUID, err := h.Service.ExtractCtxUser(ctx, false)
@@ -907,21 +942,56 @@ func (h *PublicHandler) ListPipelineTriggerChartRecords(ctx context.Context, req
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-
-	resp, err := h.Service.ListPipelineTriggerChartRecords(ctx, req, ctxUserUID)
+	pbUser, err := h.Service.GetUserByUIDAdmin(ctx, ctxUserUID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
-		return nil, fmt.Errorf("fetching credit chart records: %w", err)
+		return nil, err
+	}
+
+	var mode mgmtPB.Mode
+	var status mgmtPB.Status
+
+	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
+		filtering.DeclareStandardFunctions(),
+		filtering.DeclareIdent(constant.Start, filtering.TypeTimestamp),
+		filtering.DeclareIdent(constant.Stop, filtering.TypeTimestamp),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.OwnerName), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineUID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineReleaseID), filtering.TypeString),
+		filtering.DeclareIdent(strcase.ToLowerCamel(constant.PipelineReleaseUID), filtering.TypeString),
+		filtering.DeclareEnumIdent(strcase.ToLowerCamel(constant.TriggerMode), mode.Type()),
+		filtering.DeclareEnumIdent(constant.Status, status.Type()),
+	}...)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	filter, err := filtering.ParseFilter(req, declarations)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	pipelineTriggerChartRecords, err := h.Service.ListPipelineTriggerChartRecords(ctx, pbUser, int64(req.GetAggregationWindow()), filter)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	resp := mgmtPB.ListPipelineTriggerChartRecordsResponse{
+		PipelineTriggerChartRecords: pipelineTriggerChartRecords,
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
 		span,
 		logUUID.String(),
-		ctxUserUID,
+		uuid.FromStringOrNil(*pbUser.Uid),
 		eventName,
 	)))
 
-	return resp, nil
+	return &resp, nil
 }
 
 func (h *PublicHandler) ListUserMemberships(ctx context.Context, req *mgmtPB.ListUserMembershipsRequest) (*mgmtPB.ListUserMembershipsResponse, error) {

--- a/pkg/repository/influx.go
+++ b/pkg/repository/influx.go
@@ -3,28 +3,35 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/log"
+	"go.einride.tech/aip/filtering"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	client "github.com/influxdata/influxdb-client-go/v2"
 
 	"github.com/instill-ai/mgmt-backend/config"
+	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
+	"github.com/instill-ai/x/paginate"
 
-	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
+// Default aggregate window
+var defaultAggregationWindow = time.Hour.Nanoseconds()
+
 // InfluxDB interface
 type InfluxDB interface {
-	ListPipelineTriggerChartRecords(ctx context.Context, p ListPipelineTriggerChartRecordsParams) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error)
-	GetPipelineTriggerCount(ctx context.Context, p GetPipelineTriggerCountParams) (*mgmtpb.GetPipelineTriggerCountResponse, error)
+	QueryPipelineTriggerTableRecords(ctx context.Context, owner string, ownerQueryString string, pageSize int64, pageToken string, filter filtering.Filter) (records []*mgmtpb.PipelineTriggerTableRecord, totalSize int64, nextPageToken string, err error)
+	QueryPipelineTriggerChartRecords(ctx context.Context, owner string, ownerQueryString string, aggregationWindow int64, filter filtering.Filter) (records []*mgmtpb.PipelineTriggerChartRecord, err error)
 
 	Bucket() string
 	QueryAPI() api.QueryAPI
@@ -100,163 +107,6 @@ func (i *influxDB) Bucket() string {
 	return i.bucket
 }
 
-const qPipelineTriggerChartRecords = `
-from(bucket: "%s")
-	|> range(start: %s, stop: %s)
-	|> filter(fn: (r) => r._measurement == "pipeline.trigger" and r.requester_uid == "%s")
-	|> filter(fn: (r) => r._field == "trigger_time")
-	|> group(columns:["requester_uid"])
-	|> aggregateWindow(every: %s, column:"_value", fn: count, createEmpty: true, offset: %s)
-`
-
-// ListPipelineTriggerChartRecordsParams contains the required information to
-// query the pipeline triggers of a namespace.
-// TODO jvallesm: this should be defined in the service package for better
-// decoupling. At the moment this implies breaking an import cycle with many
-// dependencies.
-type ListPipelineTriggerChartRecordsParams struct {
-	NamespaceID       string
-	NamespaceUID      uuid.UUID
-	AggregationWindow time.Duration
-	Start             time.Time
-	Stop              time.Time
-}
-
-func (i *influxDB) ListPipelineTriggerChartRecords(
-	ctx context.Context,
-	p ListPipelineTriggerChartRecordsParams,
-) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error) {
-	l, _ := logger.GetZapLogger(ctx)
-	l = l.With(zap.Reflect("triggerChartParams", p))
-
-	query := fmt.Sprintf(
-		qPipelineTriggerChartRecords,
-		i.Bucket(),
-		p.Start.Format(time.RFC3339Nano),
-		p.Stop.Format(time.RFC3339Nano),
-		p.NamespaceUID.String(),
-		p.AggregationWindow,
-		AggregationWindowOffset(p.Start).String(),
-	)
-	result, err := i.QueryAPI().Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("%w: querying data from InfluxDB: %w", errdomain.ErrInvalidArgument, err)
-	}
-
-	defer result.Close()
-
-	record := &mgmtpb.PipelineTriggerChartRecord{
-		NamespaceId:   p.NamespaceID,
-		TimeBuckets:   []*timestamppb.Timestamp{},
-		TriggerCounts: []int32{},
-	}
-
-	// Until filtering and grouping are implemented, we'll only have one record
-	// (total triggers by requester).
-	records := []*mgmtpb.PipelineTriggerChartRecord{record}
-
-	for result.Next() {
-		t := result.Record().Time()
-		record.TimeBuckets = append(record.TimeBuckets, timestamppb.New(t))
-
-		v, match := result.Record().Value().(int64)
-		if !match {
-			l.With(zap.Time("_time", result.Record().Time())).
-				Error("Missing count on pipeline trigger chart record.")
-		}
-
-		record.TriggerCounts = append(record.TriggerCounts, int32(v))
-	}
-
-	if result.Err() != nil {
-		return nil, fmt.Errorf("collecting information from pipeline trigger chart records: %w", err)
-	}
-
-	if result.Record() == nil {
-		return nil, nil
-	}
-
-	return &mgmtpb.ListPipelineTriggerChartRecordsResponse{
-		PipelineTriggerChartRecords: records,
-	}, nil
-}
-
-const qPipelineTriggerCount = `
-from(bucket: "%s")
-	|> range(start: %s, stop: %s)
-	|> filter(fn: (r) => r._measurement == "pipeline.trigger" and r.requester_uid == "%s")
-	|> filter(fn: (r) => r._field == "trigger_time")
-	|> group(columns: ["requester_uid", "status"])
-	|> count(column: "_value")
-`
-
-// GetPipelineTriggerCountParams contains the required information to
-// query the pipeline trigger count of a namespace.
-// TODO jvallesm: this should be defined in the service package for better
-// decoupling. At the moment this implies breaking an import cycle with many
-// dependencies.
-type GetPipelineTriggerCountParams struct {
-	NamespaceUID uuid.UUID
-	Start        time.Time
-	Stop         time.Time
-}
-
-func (i *influxDB) GetPipelineTriggerCount(
-	ctx context.Context,
-	p GetPipelineTriggerCountParams,
-) (*mgmtpb.GetPipelineTriggerCountResponse, error) {
-	l, _ := logger.GetZapLogger(ctx)
-	l = l.With(zap.Reflect("triggerCountParams", p))
-
-	query := fmt.Sprintf(
-		qPipelineTriggerCount,
-		i.Bucket(),
-		p.Start.Format(time.RFC3339Nano),
-		p.Stop.Format(time.RFC3339Nano),
-		p.NamespaceUID.String(),
-	)
-	result, err := i.QueryAPI().Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("%w: querying data from InfluxDB: %w", errdomain.ErrInvalidArgument, err)
-	}
-
-	defer result.Close()
-
-	// We'll have one record per status.
-	countRecords := make([]*mgmtpb.PipelineTriggerCount, 0, 2)
-	for result.Next() {
-		l := l.With(zap.Time("_time", result.Record().Time()))
-
-		statusStr := result.Record().ValueByKey("status").(string)
-		status := mgmtpb.Status(mgmtpb.Status_value[statusStr])
-		if status == mgmtpb.Status_STATUS_UNSPECIFIED {
-			l.Error("Missing status on trigger count record.")
-		}
-
-		count, match := result.Record().Value().(int64)
-		if !match {
-			l.Error("Missing count on pipeline trigger count record.")
-		}
-
-		countRecords = append(countRecords, &mgmtpb.PipelineTriggerCount{
-			TriggerCount: int32(count),
-			Status:       &status,
-		})
-	}
-
-	if result.Err() != nil {
-		return nil, fmt.Errorf("collecting information from pipeline trigger count records: %w", err)
-	}
-
-	if result.Record() == nil {
-		return nil, nil
-	}
-
-	return &mgmtpb.GetPipelineTriggerCountResponse{
-		PipelineTriggerCounts: countRecords,
-	}, nil
-}
-
 // AggregationWindowOffset computes the offset to apply to InfluxDB's
 // aggregateWindow function when aggregating by day. This function computes
 // windows independently, starting from the Unix epoch, rather than from the
@@ -265,4 +115,339 @@ func (i *influxDB) GetPipelineTriggerCount(
 func AggregationWindowOffset(t time.Time) time.Duration {
 	startOfDay := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 	return t.Sub(startOfDay)
+}
+
+func (i *influxDB) QueryPipelineTriggerTableRecords(ctx context.Context, owner string, ownerQueryString string, pageSize int64, pageToken string, filter filtering.Filter) (records []*mgmtpb.PipelineTriggerTableRecord, totalSize int64, nextPageToken string, err error) {
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	if pageSize == 0 {
+		pageSize = DefaultPageSize
+	} else if pageSize > MaxPageSize {
+		pageSize = MaxPageSize
+	}
+
+	start := time.Time{}.Format(time.RFC3339Nano)
+	stop := time.Now().Format(time.RFC3339Nano)
+	mostRecetTimeFilter := time.Now().Format(time.RFC3339Nano)
+
+	// TODO: validate owner uid from token
+	if pageToken != "" {
+		mostRecetTime, _, err := paginate.DecodeToken(pageToken)
+		if err != nil {
+			return nil, 0, "", status.Errorf(codes.InvalidArgument, "Invalid page token: %s", err.Error())
+		}
+		mostRecetTime = mostRecetTime.Add(time.Duration(-1))
+		mostRecetTimeFilter = mostRecetTime.Format(time.RFC3339Nano)
+	}
+
+	// TODO: design better filter expression to flux transpiler
+	expr, err := i.transpileFilter(filter)
+	if err != nil {
+		return nil, 0, "", status.Errorf(codes.Internal, err.Error())
+	}
+
+	if expr != "" {
+		exprs := strings.Split(expr, "&&")
+		for i, expr := range exprs {
+			if strings.HasPrefix(expr, constant.Start) {
+				start = strings.Split(expr, "@")[1]
+				exprs[i] = ""
+			}
+			if strings.HasPrefix(expr, constant.Stop) {
+				stop = strings.Split(expr, "@")[1]
+				exprs[i] = ""
+			}
+		}
+		expr = strings.Join(exprs, "")
+	}
+
+	baseQuery := fmt.Sprintf(
+		`base =
+			from(bucket: "%v")
+				|> range(start: %v, stop: %v)
+				|> filter(fn: (r) => r["_measurement"] == "pipeline.trigger")
+				|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+				%v
+				%v
+		triggerRank =
+			base
+				|> drop(
+					columns: [
+						"owner_uid",
+						"trigger_mode",
+						"compute_time_duration",
+						"pipeline_trigger_id",
+						"status",
+					],
+				)
+				|> group(columns: ["pipeline_uid"])
+				|> map(fn: (r) => ({r with trigger_time: time(v: r.trigger_time)}))
+				|> max(column: "trigger_time")
+				|> rename(columns: {trigger_time: "most_recent_trigger_time"})
+		triggerCount =
+			base
+				|> drop(
+					columns: ["owner_uid", "trigger_mode", "compute_time_duration", "pipeline_trigger_id"],
+				)
+				|> group(columns: ["pipeline_uid", "status"])
+				|> count(column: "trigger_time")
+				|> rename(columns: {trigger_time: "trigger_count"})
+				|> group(columns: ["pipeline_uid"])
+		triggerTable =
+			join(tables: {t1: triggerRank, t2: triggerCount}, on: ["pipeline_uid"])
+				|> group()
+				|> pivot(
+					rowKey: ["pipeline_uid", "most_recent_trigger_time"],
+					columnKey: ["status"],
+					valueColumn: "trigger_count",
+				)
+				|> filter(
+					fn: (r) => r["most_recent_trigger_time"] < time(v: %v)
+				)
+		nameMap =
+			base
+				|> keep(columns: ["trigger_time", "pipeline_id", "pipeline_uid"])
+				|> group(columns: ["pipeline_uid"])
+				|> top(columns: ["trigger_time"], n: 1)
+				|> drop(columns: ["trigger_time"])
+				|> group()
+		join(tables: {t1: triggerTable, t2: nameMap}, on: ["pipeline_uid"])`,
+		i.bucket,
+		start,
+		stop,
+		ownerQueryString,
+		expr,
+		mostRecetTimeFilter,
+	)
+
+	query := fmt.Sprintf(
+		`%v
+		|> group()
+		|> sort(columns: ["most_recent_trigger_time"], desc: true)
+		|> limit(n: %v)`,
+		baseQuery,
+		pageSize,
+	)
+
+	totalQuery := fmt.Sprintf(
+		`%v
+		|> group()
+		|> count(column: "pipeline_uid")`,
+		baseQuery,
+	)
+
+	var lastTimestamp time.Time
+
+	result, err := i.api.Query(ctx, query)
+	if err != nil {
+		return nil, 0, "", status.Errorf(codes.InvalidArgument, "Invalid query: %s", err.Error())
+	} else {
+		// Iterate over query response
+		for result.Next() {
+			// Notice when group key has changed
+			if result.TableChanged() {
+				logger.Debug(fmt.Sprintf("table: %s\n", result.TableMetadata().String()))
+			}
+
+			tableRecord := &mgmtpb.PipelineTriggerTableRecord{}
+
+			if v, match := result.Record().ValueByKey(constant.PipelineID).(string); match {
+				tableRecord.PipelineId = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineUID).(string); match {
+				tableRecord.PipelineUid = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineReleaseID).(string); match {
+				tableRecord.PipelineReleaseId = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineReleaseUID).(string); match {
+				tableRecord.PipelineReleaseUid = v
+			}
+			if v, match := result.Record().ValueByKey(mgmtpb.Status_STATUS_COMPLETED.String()).(int64); match {
+				tableRecord.TriggerCountCompleted = int32(v)
+			}
+			if v, match := result.Record().ValueByKey(mgmtpb.Status_STATUS_ERRORED.String()).(int64); match {
+				tableRecord.TriggerCountErrored = int32(v)
+			}
+
+			records = append(records, tableRecord)
+		}
+
+		// Check for an error
+		if result.Err() != nil {
+			return nil, 0, "", status.Errorf(codes.InvalidArgument, "Invalid query: %s", err.Error())
+		}
+		if result.Record() == nil {
+			return nil, 0, "", nil
+		}
+
+		if v, match := result.Record().ValueByKey("most_recent_trigger_time").(time.Time); match {
+			lastTimestamp = v
+		}
+	}
+
+	var total int64
+	totalQueryResult, err := i.api.Query(ctx, totalQuery)
+	if err != nil {
+		return nil, 0, "", status.Errorf(codes.InvalidArgument, "Invalid total query: %s", err.Error())
+	} else {
+		if totalQueryResult.Next() {
+			total = totalQueryResult.Record().ValueByKey(constant.PipelineUID).(int64)
+		}
+	}
+
+	if int64(len(records)) < total {
+		pageToken = paginate.EncodeToken(lastTimestamp, owner)
+	} else {
+		pageToken = ""
+	}
+
+	return records, int64(len(records)), pageToken, nil
+}
+
+func (i *influxDB) QueryPipelineTriggerChartRecords(ctx context.Context, owner string, ownerQueryString string, aggregationWindow int64, filter filtering.Filter) (records []*mgmtpb.PipelineTriggerChartRecord, err error) {
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	start := time.Time{}.Format(time.RFC3339Nano)
+	stop := time.Now().Format(time.RFC3339Nano)
+
+	if aggregationWindow < time.Minute.Nanoseconds() {
+		aggregationWindow = defaultAggregationWindow
+	}
+
+	// TODO: design better filter expression to flux transpiler
+	expr, err := i.transpileFilter(filter)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+
+	if expr != "" {
+		exprs := strings.Split(expr, "&&")
+		for i, expr := range exprs {
+			if strings.HasPrefix(expr, constant.Start) {
+				start = strings.Split(expr, "@")[1]
+				exprs[i] = ""
+			}
+			if strings.HasPrefix(expr, constant.Stop) {
+				stop = strings.Split(expr, "@")[1]
+				exprs[i] = ""
+			}
+		}
+		expr = strings.Join(exprs, "")
+	}
+
+	query := fmt.Sprintf(
+		`base =
+			from(bucket: "%v")
+				|> range(start: %v, stop: %v)
+				|> filter(fn: (r) => r["_measurement"] == "pipeline.trigger")
+				|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+				%v
+				%v
+		bucketBase =
+			base
+				|> group(columns: ["pipeline_uid"])
+				|> sort(columns: ["trigger_time"])
+		bucketTrigger =
+			bucketBase
+				|> aggregateWindow(
+					every: duration(v: %v),
+					column: "trigger_time",
+					fn: count,
+					createEmpty: false,
+				)
+		bucketDuration =
+			bucketBase
+				|> aggregateWindow(
+					every: duration(v: %v),
+					fn: sum,
+					column: "compute_time_duration",
+					createEmpty: false,
+				)
+		bucket =
+			join(
+				tables: {t1: bucketTrigger, t2: bucketDuration},
+				on: ["_start", "_stop", "_time", "pipeline_uid"],
+			)
+		nameMap =
+			base
+				|> keep(columns: ["trigger_time", "pipeline_id", "pipeline_uid"])
+				|> group(columns: ["pipeline_uid"])
+				|> top(columns: ["trigger_time"], n: 1)
+				|> drop(columns: ["trigger_time"])
+		join(tables: {t1: bucket, t2: nameMap}, on: ["pipeline_uid"])`,
+		i.bucket,
+		start,
+		stop,
+		ownerQueryString,
+		expr,
+		aggregationWindow,
+		aggregationWindow,
+	)
+
+	result, err := i.api.Query(ctx, query)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid query: %s", err.Error())
+	}
+
+	var currentTablePosition = -1
+	var chartRecord *mgmtpb.PipelineTriggerChartRecord
+
+	// Iterate over query response
+	for result.Next() {
+		// Notice when group key has changed
+		if result.TableChanged() {
+			logger.Debug(fmt.Sprintf("table: %s\n", result.TableMetadata().String()))
+		}
+
+		if result.Record().Table() != currentTablePosition {
+			chartRecord = &mgmtpb.PipelineTriggerChartRecord{}
+
+			if v, match := result.Record().ValueByKey(constant.PipelineID).(string); match {
+				chartRecord.PipelineId = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineUID).(string); match {
+				chartRecord.PipelineUid = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineReleaseID).(string); match {
+				chartRecord.PipelineReleaseId = v
+			}
+			if v, match := result.Record().ValueByKey(constant.PipelineReleaseUID).(string); match {
+				chartRecord.PipelineReleaseUid = v
+			}
+			chartRecord.TimeBuckets = []*timestamppb.Timestamp{}
+			chartRecord.TriggerCounts = []int32{}
+			chartRecord.ComputeTimeDuration = []float32{}
+			records = append(records, chartRecord)
+			currentTablePosition = result.Record().Table()
+		}
+
+		if v, match := result.Record().ValueByKey("_time").(time.Time); match {
+			chartRecord.TimeBuckets = append(chartRecord.TimeBuckets, timestamppb.New(v))
+		}
+		if v, match := result.Record().ValueByKey(constant.TriggerTime).(int64); match {
+			chartRecord.TriggerCounts = append(chartRecord.TriggerCounts, int32(v))
+		}
+		if v, match := result.Record().ValueByKey(constant.ComputeTimeDuration).(float64); match {
+			chartRecord.ComputeTimeDuration = append(chartRecord.ComputeTimeDuration, float32(v))
+		}
+	}
+	// Check for an error
+	if result.Err() != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid query: %s", err.Error())
+	}
+	if result.Record() == nil {
+		return nil, nil
+	}
+
+	return records, nil
+}
+
+// TranspileFilter transpiles a parsed AIP filter expression to Flux query expression
+func (i *influxDB) transpileFilter(filter filtering.Filter) (string, error) {
+	return (&Transpiler{
+		filter: filter,
+	}).Transpile()
 }

--- a/pkg/service/metric.go
+++ b/pkg/service/metric.go
@@ -5,87 +5,162 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
+	"go.einride.tech/aip/filtering"
 	"gorm.io/gorm"
 
 	"github.com/gofrs/uuid"
+	"github.com/instill-ai/mgmt-backend/internal/resource"
 	"github.com/instill-ai/mgmt-backend/pkg/acl"
+	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/repository"
 
 	errdomain "github.com/instill-ai/mgmt-backend/pkg/errors"
-	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-func (s *service) GetPipelineTriggerCount(
-	ctx context.Context,
-	req *mgmtpb.GetPipelineTriggerCountRequest,
-	ctxUserUID uuid.UUID,
-) (*mgmtpb.GetPipelineTriggerCountResponse, error) {
-	nsUID, err := s.GrantedNamespaceUID(ctx, req.GetNamespaceId(), ctxUserUID)
-	if err != nil {
-		return nil, fmt.Errorf("checking user permissions: %w", err)
+var ErrNoPermission = errors.New("no permission")
+
+func (s *service) checkPipelineOwnership(ctx context.Context, filter filtering.Filter, owner *mgmtPB.User) (*string, string, string, string, filtering.Filter, error) {
+	ownerID := owner.Id
+	ownerUID := owner.Uid
+	ownerType := "users"
+	ownerQueryString := ""
+
+	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {
+
+		ownerName, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.OwnerName, false)
+
+		if ownerName != "" {
+
+			if strings.HasPrefix(ownerName, "users") {
+				if ownerName != fmt.Sprintf("users/%s", owner.Id) {
+					return nil, "", "", "", filter, ErrNoPermission
+				}
+				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.OwnerName, constant.PipelineOwnerUID, *owner.Uid, false)
+			} else if strings.HasPrefix(ownerName, "organizations") {
+				ownerType = "organizations"
+				id, err := resource.GetRscNameID(ownerName)
+				if err != nil {
+					return nil, "", "", "", filter, err
+				}
+				ownerID = id
+				org, err := s.GetOrganizationAdmin(ctx, id)
+				if err != nil {
+					return nil, "", "", "", filter, err
+				}
+				granted, err := s.GetACLClient().CheckPermission(ctx, "organization", uuid.FromStringOrNil(org.Uid), "user", uuid.FromStringOrNil(owner.GetUid()), "", "member")
+				if err != nil {
+					return nil, "", "", "", filter, err
+				}
+				if !granted {
+					return nil, "", "", "", filter, ErrNoPermission
+				}
+				repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.OwnerName, constant.PipelineOwnerUID, org.Uid, false)
+				ownerUID = &org.Uid
+			} else {
+				return nil, "", "", "", filter, ErrInvalidOwnerNamespace
+			}
+		} else {
+			ownerQueryString = fmt.Sprintf("|> filter(fn: (r) => r[\"owner_uid\"] == \"%v\")", *owner.Uid)
+		}
+	} else {
+		ownerQueryString = fmt.Sprintf("|> filter(fn: (r) => r[\"owner_uid\"] == \"%v\")", *owner.Uid)
 	}
-
-	now := time.Now().UTC()
-	p := repository.GetPipelineTriggerCountParams{
-		NamespaceUID: nsUID,
-
-		// Default values
-		Start: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()),
-		Stop:  now,
-	}
-
-	if req.GetStart() != nil {
-		p.Start = req.GetStart().AsTime()
-	}
-
-	if req.GetStop() != nil {
-		p.Stop = req.GetStop().AsTime()
-	}
-
-	return s.influxDB.GetPipelineTriggerCount(ctx, p)
+	return ownerUID, ownerID, ownerType, ownerQueryString, filter, nil
 }
 
-func (s *service) ListPipelineTriggerChartRecords(
-	ctx context.Context,
-	req *mgmtpb.ListPipelineTriggerChartRecordsRequest,
-	ctxUserUID uuid.UUID,
-) (*mgmtpb.ListPipelineTriggerChartRecordsResponse, error) {
-	nsUID, err := s.GrantedNamespaceUID(ctx, req.GetNamespaceId(), ctxUserUID)
-	if err != nil {
-		return nil, fmt.Errorf("checking user permissions: %w", err)
-	}
+func (s *service) pipelineUIDLookup(ctx context.Context, ownerID string, ownerType string, filter filtering.Filter, owner *mgmtPB.User) (filtering.Filter, error) {
 
-	now := time.Now().UTC()
-	p := repository.ListPipelineTriggerChartRecordsParams{
-		NamespaceID:  req.GetNamespaceId(),
-		NamespaceUID: nsUID,
+	ctx = InjectOwnerToContext(ctx, *owner.Uid)
 
-		// Default values
-		AggregationWindow: 1 * time.Hour,
-		Start:             time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()),
-		Stop:              now,
-	}
+	// lookup pipeline uid
+	if len(filter.CheckedExpr.GetExpr().GetCallExpr().GetArgs()) > 0 {
+		pipelineID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, false)
 
-	if req.GetAggregationWindow() != "" {
-		window, err := time.ParseDuration(req.GetAggregationWindow())
-		if err != nil {
-			return nil, fmt.Errorf("%w: extracting duration from aggregation window: %w", errdomain.ErrInvalidArgument, err)
+		if pipelineID != "" {
+			if ownerType == "users" {
+				if respPipeline, err := s.pipelinePublicServiceClient.GetUserPipeline(ctx, &pipelinePB.GetUserPipelineRequest{
+					Name: fmt.Sprintf("%s/pipelines/%s", owner.Name, pipelineID),
+				}); err != nil {
+					return filter, err
+				} else {
+					repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipeline.Pipeline.Uid, false)
+
+					// lookup pipeline release uid
+					pipelineReleaseID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineReleaseID, false)
+
+					respPipelineRelease, err := s.pipelinePublicServiceClient.GetUserPipelineRelease(ctx, &pipelinePB.GetUserPipelineReleaseRequest{
+						Name: fmt.Sprintf("%s/pipelines/%s/releases/%s", owner.Name, pipelineID, pipelineReleaseID),
+					})
+					if err == nil {
+						repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipelineRelease.Release.Uid, false)
+					}
+				}
+			} else if ownerType == "organizations" {
+				if respPipeline, err := s.pipelinePublicServiceClient.GetOrganizationPipeline(ctx, &pipelinePB.GetOrganizationPipelineRequest{
+					Name: fmt.Sprintf("organizations/%s/pipelines/%s", ownerID, pipelineID),
+				}); err != nil {
+					return filter, err
+				} else {
+					repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipeline.Pipeline.Uid, false)
+
+					// lookup pipeline release uid
+					pipelineReleaseID, _ := repository.ExtractConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineReleaseID, false)
+
+					respPipelineRelease, err := s.pipelinePublicServiceClient.GetUserPipelineRelease(ctx, &pipelinePB.GetUserPipelineReleaseRequest{
+						Name: fmt.Sprintf("organizations/%s/pipelines/%s/releases/%s", ownerID, pipelineID, pipelineReleaseID),
+					})
+					if err == nil {
+						repository.HijackConstExpr(filter.CheckedExpr.GetExpr(), constant.PipelineID, constant.PipelineUID, respPipelineRelease.Release.Uid, false)
+					}
+				}
+			}
 		}
-
-		p.AggregationWindow = window
 	}
 
-	if req.GetStart() != nil {
-		p.Start = req.GetStart().AsTime()
+	return filter, nil
+}
+
+func (s *service) ListPipelineTriggerTableRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerTableRecord, int64, string, error) {
+
+	ownerUID, ownerID, ownerType, ownerQueryString, filter, err := s.checkPipelineOwnership(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerTableRecord{}, 0, "", err
 	}
 
-	if req.GetStop() != nil {
-		p.Stop = req.GetStop().AsTime()
+	filter, err = s.pipelineUIDLookup(ctx, ownerID, ownerType, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerTableRecord{}, 0, "", nil
 	}
 
-	return s.influxDB.ListPipelineTriggerChartRecords(ctx, p)
+	pipelineTriggerTableRecords, ps, pt, err := s.influxDB.QueryPipelineTriggerTableRecords(ctx, *ownerUID, ownerQueryString, pageSize, pageToken, filter)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	return pipelineTriggerTableRecords, ps, pt, nil
+}
+
+func (s *service) ListPipelineTriggerChartRecords(ctx context.Context, owner *mgmtPB.User, aggregationWindow int64, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerChartRecord, error) {
+
+	ownerUID, ownerID, ownerType, ownerQueryString, filter, err := s.checkPipelineOwnership(ctx, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerChartRecord{}, err
+	}
+
+	filter, err = s.pipelineUIDLookup(ctx, ownerID, ownerType, filter, owner)
+	if err != nil {
+		return []*mgmtPB.PipelineTriggerChartRecord{}, nil
+	}
+
+	pipelineTriggerChartRecords, err := s.influxDB.QueryPipelineTriggerChartRecords(ctx, *ownerUID, ownerQueryString, aggregationWindow, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return pipelineTriggerChartRecords, nil
 }
 
 // GrantedNamespaceUID returns the UID of a namespace, provided the

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -70,8 +70,8 @@ type Service interface {
 	CheckUserPassword(ctx context.Context, uid uuid.UUID, password string) error
 	UpdateUserPassword(ctx context.Context, uid uuid.UUID, newPassword string) error
 
-	GetPipelineTriggerCount(_ context.Context, _ *mgmtPB.GetPipelineTriggerCountRequest, ctxUserUID uuid.UUID) (*mgmtPB.GetPipelineTriggerCountResponse, error)
-	ListPipelineTriggerChartRecords(_ context.Context, _ *mgmtPB.ListPipelineTriggerChartRecordsRequest, ctxUserUID uuid.UUID) (*mgmtPB.ListPipelineTriggerChartRecordsResponse, error)
+	ListPipelineTriggerTableRecords(ctx context.Context, owner *mgmtPB.User, pageSize int64, pageToken string, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerTableRecord, int64, string, error)
+	ListPipelineTriggerChartRecords(ctx context.Context, owner *mgmtPB.User, aggregationWindow int64, filter filtering.Filter) ([]*mgmtPB.PipelineTriggerChartRecord, error)
 
 	DBUser2PBUser(ctx context.Context, dbUser *datamodel.Owner) (*mgmtPB.User, error)
 	DBUsers2PBUsers(ctx context.Context, dbUsers []*datamodel.Owner) ([]*mgmtPB.User, error)


### PR DESCRIPTION
Because

- The new dashboard endpoints introduced breaking changes and the clients won't be ready for the upcoming release.

This commit

- Restores the previous dashboard endpoints.