### PR TITLE
fix(dashboard): broken InfluxDB query on trigger count

### DIFF
--- a/pkg/repository/influx.go
+++ b/pkg/repository/influx.go
@@ -183,7 +183,8 @@ func (i *influxDB) QueryPipelineTriggerTableRecords(ctx context.Context, owner s
 				)
 				|> group(columns: ["pipeline_uid"])
 				|> map(fn: (r) => ({r with trigger_time: time(v: r.trigger_time)}))
-				|> max(column: "trigger_time")
+				|> sort(columns: ["trigger_time"], desc: true)
+				|> first(column: "trigger_time")
 				|> rename(columns: {trigger_time: "most_recent_trigger_time"})
 		triggerCount =
 			base


### PR DESCRIPTION
Because

- The `GET https://api.instill.tech/v1beta/metrics/vdp/pipeline/tables` endpoint (for relatively large datasets and time ranges) returned the following error:

```
message: "Invalid query: internal error: panic: arrow/array: index out of range"
```

- The culprit was the `max` function used in the [InfluxDB query](https://github.com/instill-ai/mgmt-backend/blob/main/pkg/repository/influx.go#L186).


This commit

- Replaces the `max` function by `sort` + `first`, which don't produce the error.
