### PR TITLE
chore(proto): adopt latest `protogen-go` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241120170237-ee31d10bc9c8
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0 h1:AjbBfJuq+QoaXNcrova8smSjw
 github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3IftVLVezreAUtBOTZssDrjZEFHI=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241120170237-ee31d10bc9c8 h1:Mq87LDBN4fmpN7tD/UMTMahqR/FupEHVIPCPqLZh4XI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241120170237-ee31d10bc9c8/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61 h1:wA9YlKStdlutjW/QxlTZApNFJXRivFvlqsUiwKz4MlQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/proto/core/mgmt/v1beta/mgmt.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt.proto
@@ -123,8 +123,6 @@ message OrganizationProfile {
 // the public user information plus some fields that should only be accessed by
 // the user themselves.
 message AuthenticatedUser {
-  option (google.api.resource) = {type: "api.instill-ai.com/AuthenticatedUser"};
-
   // The name of the user, defined by its ID.
   // - Format: `users/{user.id}`.
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -182,7 +180,6 @@ message Owner {
 // contain any private information about the user.
 message User {
   option (google.api.resource) = {
-    type: "api.instill-ai.com/User"
     pattern: "users/{user.id}"
     pattern: "users/{user.uid}"
   };
@@ -360,10 +357,7 @@ message GetUserRequest {
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // User ID
-  string user_id = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/User"
-  ];
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetUserResponse contains the requested user.
@@ -505,8 +499,6 @@ message CheckNamespaceByUIDAdminResponse {
 
 // API tokens allow users to make requests to the Instill AI API.
 message ApiToken {
-  option (google.api.resource) = {type: "api.instill-ai.com/ApiToken"};
-
   // When users trigger a pipeline which uses an API token, the token is
   // updated with the current time. This field is used to track the last time
   // the token was used.
@@ -596,10 +588,7 @@ message GetTokenRequest {
   // Reserverd for `name`
   reserved 1;
   // Token ID
-  string token_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill-ai.com/ApiToken"}
-  ];
+  string token_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetTokenResponse contains the requested token.
@@ -613,10 +602,7 @@ message DeleteTokenRequest {
   // Reserverd for `name`
   reserved 1;
   // Token ID
-  string token_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill-ai.com/ApiToken"}
-  ];
+  string token_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteTokenResponse is an empty response.
@@ -760,10 +746,7 @@ message AuthChangePasswordResponse {}
 // Organizations group several users. As entities, they can own resources such
 // as pipelines or releases.
 message Organization {
-  option (google.api.resource) = {
-    type: "api.instill-ai.com/Organization"
-    pattern: "organizations/{organization.id}"
-  };
+  option (google.api.resource) = {pattern: "organizations/{organization.id}"};
 
   // The name of the organization, defined by its ID.
   // - Format: `organization/{organization.id}`.
@@ -836,10 +819,7 @@ message GetOrganizationRequest {
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // Organization ID
-  string organization_id = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/Organization"
-  ];
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationResponse contains the requested organization.
@@ -872,10 +852,7 @@ message DeleteOrganizationRequest {
   // Reserverd for `name`
   reserved 1;
   // Organization ID
-  string organization_id = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill-ai.com/Organization"
-  ];
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteOrganizationResponse is an empty response.
@@ -1119,8 +1096,10 @@ message UserSubscription {
     PLAN_UNSPECIFIED = 0;
     // Free plan.
     PLAN_FREE = 1;
-    // Pro plan.
-    PLAN_PRO = 2;
+    // 2 is reserved for the deprecated PLAN_PRO value.
+    reserved 2;
+    // Starter plan.
+    PLAN_STARTER = 3;
   }
 
   // Plan identifier.

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
@@ -405,7 +405,7 @@ service MgmtPublicService {
 
   // Get the remaining Instill Credit
   //
-  // This endpoint returns the remaining [Instill Credit](https://www.instill-ai.dev/docs/vdp/credit) of a given user or
+  // This endpoint returns the remaining [Instill Credit](https://instill-ai.dev/docs/cloud/credit) of a given user or
   // organization. The requested credit owner must be either the authenticated
   // user or an organization they belong to.
   //
@@ -597,7 +597,6 @@ service MgmtPublicService {
     option deprecated = true;
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
-
 
   // List pipeline trigger metrics
   //


### PR DESCRIPTION
Because

- we've updated the enum for user plan.

This commit

- adopts latest `protogen-go` package.
