### PR TITLE
ci(workflows): adopt short commit hash for service version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,12 @@
 name: Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   codecov:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,11 @@ name: golangci-lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -34,6 +34,11 @@ jobs:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and push (latest)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
@@ -43,6 +48,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/mgmt-backend:latest
           cache-from: type=registry,ref=instill/mgmt-backend:buildcache
           cache-to: type=registry,ref=instill/mgmt-backend:buildcache,mode=max
@@ -67,6 +73,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/mgmt-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/mgmt-backend:buildcache
           cache-to: type=registry,ref=instill/mgmt-backend:buildcache,mode=max

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,15 +9,8 @@ on:
       - main
 
 jobs:
-  build-push-image:
-    if: github.ref == 'refs/heads/main'
-    name: Build and push image
-    uses: instill-ai/mgmt-backend/.github/workflows/images.yml@main
-    secrets: inherit
-
-  pr-head:
-    if: github.event_name == 'pull_request'
-    name: PR head branch
+  integration-test:
+    name: Integration test
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -78,9 +71,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get short SHA
-        id: short-sha
-        run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+      - name: Set short commit SHA
+        run: |
+          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build image
         uses: docker/build-push-action@v6
@@ -89,8 +82,8 @@ jobs:
           load: true
           build-args: |
             SERVICE_NAME=mgmt-backend
-            SERVICE_VERSION=${{ steps.short-sha.outputs.SHORT_SHA }}
-          tags: instill/mgmt-backend:${{ steps.short-sha.outputs.SHORT_SHA }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
+          tags: instill/mgmt-backend:latest
           cache-from: |
             type=registry,ref=instill/mgmt-backend:buildcache
           cache-to: |
@@ -99,7 +92,7 @@ jobs:
       - name: Launch Instill Core CE (latest)
         working-directory: instill-core
         run: |
-          make latest EDITION=local-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test
+          make latest EDITION=docker-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test
 
       - name: Run integration-test
         working-directory: mgmt-backend

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -48,7 +48,13 @@ import (
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
-var propagator propagation.TextMapPropagator
+var (
+	// These variables might be overridden at buildtime.
+	serviceVersion = "dev"
+	// serviceName = "mgmt-backend"
+
+	propagator propagation.TextMapPropagator
+)
 
 func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler) http.Handler {
 	return h2c.NewHandler(
@@ -209,7 +215,7 @@ func main() {
 			logger.Info("try to start usage reporter")
 			go func() {
 				for {
-					usg = usage.NewUsage(ctx, service, usageServiceClient, config.Config.Server.Edition, constant.DefaultUserID)
+					usg = usage.NewUsage(ctx, service, usageServiceClient, serviceVersion)
 					if usg != nil {
 						usg.StartReporter(ctx)
 						logger.Info("usage reporter started")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -23,6 +23,12 @@ import (
 	mgmtworker "github.com/instill-ai/mgmt-backend/pkg/worker"
 )
 
+var (
+	// These variables might be overridden at buildtime.
+	// version     = "dev"
+	// serviceName = "mgmt-backend"
+)
+
 func initTemporalNamespace(ctx context.Context, client client.Client) {
 	logger, _ := logger.GetZapLogger(ctx)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@ server:
   https:
     cert:
     key:
-  edition: local-ce:dev
+  edition: docker-ce:dev
   usage:
     enabled: true
     tlsenabled: true

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/instill-ai/mgmt-backend/config"
+	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/logger"
 	"github.com/instill-ai/mgmt-backend/pkg/service"
-	"github.com/instill-ai/x/repo"
 	"go.einride.tech/aip/filtering"
 
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
@@ -18,53 +19,43 @@ import (
 
 // Usage interface
 type Usage interface {
-	RetrieveUsageData() interface{}
+	RetrieveUsageData() any
 	StartReporter(ctx context.Context)
 	TriggerSingleReporter(ctx context.Context)
 }
 
 type usage struct {
-	service       service.Service
-	reporter      usageReporter.Reporter
-	edition       string
-	version       string
-	defaultUserID string
+	service        service.Service
+	reporter       usageReporter.Reporter
+	serviceVersion string
 }
 
 // NewUsage initiates a usage instance
-func NewUsage(ctx context.Context, s service.Service, usc usagePB.UsageServiceClient, edition string, defaultUserID string) Usage {
+func NewUsage(ctx context.Context, s service.Service, usc usagePB.UsageServiceClient, serviceVersion string) Usage {
 	logger, _ := logger.GetZapLogger(ctx)
 
-	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
-	if err != nil {
-		logger.Error(err.Error())
-		return nil
-	}
-
 	var defaultOwnerUID string
-	if user, err := s.GetUserAdmin(ctx, defaultUserID); err == nil {
+	if user, err := s.GetUserAdmin(ctx, constant.DefaultUserID); err == nil {
 		defaultOwnerUID = *user.Uid
 	} else {
 		logger.Error(err.Error())
 	}
 
-	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_MGMT, edition, version, defaultOwnerUID)
+	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, serviceVersion, defaultOwnerUID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil
 	}
 
 	return &usage{
-		service:       s,
-		reporter:      reporter,
-		edition:       edition,
-		version:       version,
-		defaultUserID: defaultUserID,
+		service:        s,
+		reporter:       reporter,
+		serviceVersion: serviceVersion,
 	}
 }
 
 // RetrieveUsageData retrieves the server's usage data
-func (u *usage) RetrieveUsageData() interface{} {
+func (u *usage) RetrieveUsageData() any {
 	ctx := context.Background()
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Debug("[mgmt-backend] retrieve usage data...")
@@ -122,7 +113,7 @@ func (u *usage) StartReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger(ctx)
 
 	var defaultOwnerUID string
-	if user, err := u.service.GetUserAdmin(ctx, u.defaultUserID); err == nil {
+	if user, err := u.service.GetUserAdmin(ctx, constant.DefaultUserID); err == nil {
 		defaultOwnerUID = *user.Uid
 	} else {
 		logger.Error(err.Error())
@@ -130,7 +121,7 @@ func (u *usage) StartReporter(ctx context.Context) {
 
 	go func() {
 		time.Sleep(5 * time.Second)
-		err := usageClient.StartReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, u.edition, u.version, defaultOwnerUID, u.RetrieveUsageData)
+		err := usageClient.StartReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.serviceVersion, defaultOwnerUID, u.RetrieveUsageData)
 		if err != nil {
 			logger.Error(fmt.Sprintf("unable to start reporter: %v\n", err))
 		}
@@ -145,13 +136,13 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger(ctx)
 
 	var defaultOwnerUID string
-	if user, err := u.service.GetUserAdmin(ctx, u.defaultUserID); err == nil {
+	if user, err := u.service.GetUserAdmin(ctx, constant.DefaultUserID); err == nil {
 		defaultOwnerUID = *user.Uid
 	} else {
 		logger.Error(err.Error())
 	}
 
-	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, u.edition, u.version, defaultOwnerUID, u.RetrieveUsageData())
+	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.serviceVersion, defaultOwnerUID, u.RetrieveUsageData())
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
 	} else {


### PR DESCRIPTION
Because

- the current build-time backend versioning logic is wrong.

This commit

- fixed the versioning logic and assigned short commit hash to all backend services.
