### PR TITLE
refactor(config): remove db version from config file

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 
 	"github.com/instill-ai/mgmt-backend/config"
+	"github.com/instill-ai/mgmt-backend/pkg/db"
 )
 
 func checkExist(databaseConfig config.DatabaseConfig) error {
@@ -106,7 +107,7 @@ func main() {
 		panic(err)
 	}
 
-	ExpectedVersion := databaseConfig.Version
+	ExpectedVersion := uint(db.TargetSchemaVersion)
 
 	fmt.Printf("Expected migration version is %d\n", ExpectedVersion)
 	fmt.Printf("The current schema version is %d, and dirty flag is %t\n", curVersion, dirty)

--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,6 @@ type DatabaseConfig struct {
 		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
 	} `koanf:"replica"`
 	Name     string `koanf:"name"`
-	Version  uint   `koanf:"version"`
 	TimeZone string `koanf:"timezone"`
 	Pool     struct {
 		IdleConnections int           `koanf:"idleconnections"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,6 @@ database:
   host: pg-sql
   port: 5432
   name: mgmt
-  version: 5
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -15,6 +15,8 @@ import (
 var db *gorm.DB
 var once sync.Once
 
+const TargetSchemaVersion = 5
+
 // GetConnection returns a database instance
 func GetConnection(databaseConfig *config.DatabaseConfig) *gorm.DB {
 	once.Do(func() {


### PR DESCRIPTION
Because

- The DB version should always be bound to the codebase; we shouldn’t use a config file for it.

This commit

- Removes the DB version from the config file.