### PR TITLE
fix(migrate): skips OpenFGA migration if no OpenFGA stores found

### DIFF
--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -79,7 +79,8 @@ func (fm *FGAMigration) Migrate() error {
 	}
 
 	if len(stores.Stores) == 0 {
-		return fmt.Errorf("no OpenFGA stores found")
+		fm.Logger.Info("No OpenFGA stores found, skipping FGA migration")
+		return nil
 	}
 
 	storeID := stores.Stores[0].Id


### PR DESCRIPTION
This commit

- skips OpenFGA migration if no OpenFGA stores found
