### PR TITLE
fix(cmd): move Temporal namespace creation to cmd/init

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -4,14 +4,24 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/opentelemetry"
+	"go.temporal.io/sdk/interceptor"
+	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gorm.io/gorm"
 
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -26,7 +36,10 @@ import (
 	database "github.com/instill-ai/mgmt-backend/pkg/db"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	logx "github.com/instill-ai/x/log"
+	"github.com/instill-ai/x/temporal"
 )
+
+var serviceName = "mgmt-backend-worker"
 
 func main() {
 	if err := config.Init(config.ParseConfigFlag()); err != nil {
@@ -65,6 +78,34 @@ func main() {
 	// Create preset organization
 	if err := preset.CreatePresetOrg(ctx, r); err != nil {
 		logger.Fatal(err.Error())
+	}
+
+	temporalClientOptions, err := temporal.ClientOptions(config.Config.Temporal, logger)
+	if err != nil {
+		logger.Fatal("Unable to build Temporal client options", zap.Error(err))
+	}
+
+	// Only add interceptor if tracing is enabled
+	if config.Config.OTELCollector.Enable {
+		temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
+			Tracer:            otel.Tracer(serviceName),
+			TextMapPropagator: otel.GetTextMapPropagator(),
+		})
+		if err != nil {
+			logger.Fatal("Unable to create temporal tracing interceptor", zap.Error(err))
+		}
+		temporalClientOptions.Interceptors = []interceptor.ClientInterceptor{temporalTracingInterceptor}
+	}
+
+	temporalClient, err := client.Dial(temporalClientOptions)
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Unable to create client: %s", err))
+	}
+	defer temporalClient.Close()
+
+	// for only local temporal cluster
+	if config.Config.Temporal.ServerRootCA == "" && config.Config.Temporal.ClientCert == "" && config.Config.Temporal.ClientKey == "" {
+		initTemporalNamespace(ctx, temporalClient, logger)
 	}
 
 }
@@ -136,4 +177,45 @@ func createDefaultUser(ctx context.Context, r repository.Repository) error {
 		return err
 	}
 	return nil
+}
+
+func initTemporalNamespace(ctx context.Context, client client.Client, logger *zap.Logger) {
+
+	resp, err := client.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{})
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Unable to list namespaces: %s", err))
+	}
+
+	found := false
+	for _, n := range resp.GetNamespaces() {
+		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
+			found = true
+		}
+	}
+
+	if !found {
+		if _, err := client.WorkflowService().RegisterNamespace(ctx,
+			&workflowservice.RegisterNamespaceRequest{
+				Namespace: config.Config.Temporal.Namespace,
+				WorkflowExecutionRetentionPeriod: func() *durationpb.Duration {
+					// Check if the string ends with "d" for day.
+					s := config.Config.Temporal.Retention
+					if strings.HasSuffix(s, "d") {
+						// Parse the number of days.
+						days, err := strconv.Atoi(s[:len(s)-1])
+						if err != nil {
+							logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
+						}
+						// Convert days to hours and then to a duration.
+						t := time.Hour * 24 * time.Duration(days)
+						return durationpb.New(t)
+					}
+					logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
+					return nil
+				}(),
+			},
+		); err != nil {
+			logger.Fatal(fmt.Sprintf("Unable to register namespace: %s", err))
+		}
+	}
 }


### PR DESCRIPTION
Because

- the Temporal namespace needs to be created before both `cmd/main` and `cmd/worker`.

This commit

- moves Temporal namespace creation to cmd/init
