### PR TITLE
feat(service): return user_count in the organization object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250722081303-b5398bb8b1fa
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0 h1:AjbBfJuq+QoaXNcrova8smSjw
 github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3IftVLVezreAUtBOTZssDrjZEFHI=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033 h1:jhP9Gz7tw57rTTHQ7WhHOWf7z/worMcfr/n3NAcjbD4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250722081303-b5398bb8b1fa h1:IF4HjxEd3w76l/83Cyj0bli8eu/I7h1oW1y3HPWCTzE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250722081303-b5398bb8b1fa/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=

--- a/pkg/service/convertor.go
+++ b/pkg/service/convertor.go
@@ -317,6 +317,10 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 			return nil, err
 		}
 	}
+	users, err := s.aclClient.GetOrganizationUsers(ctx, dbOrg.UID)
+	if err != nil {
+		return nil, err
+	}
 
 	return &mgmtpb.Organization{
 		Name:       fmt.Sprintf("organizations/%s", id),
@@ -334,6 +338,9 @@ func (s *service) DBOrg2PBOrg(ctx context.Context, dbOrg *datamodel.Owner) (*mgm
 		Owner: owner,
 		Permission: &mgmtpb.Permission{
 			CanEdit: canUpdateOrganization,
+		},
+		Stats: &mgmtpb.Organization_Stats{
+			UserCount: int32(len(users)),
 		},
 	}, nil
 }


### PR DESCRIPTION
Because

- We want to make it easier for users to get the number of users in the organization.

This commit

- Returns the number of users in the organization.