### PR TITLE
feat(temporal): remove Temporal namespace initialization

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -4,24 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/otel"
-	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/contrib/opentelemetry"
-	"go.temporal.io/sdk/interceptor"
-	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"gorm.io/gorm"
 
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -36,10 +26,7 @@ import (
 	database "github.com/instill-ai/mgmt-backend/pkg/db"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	logx "github.com/instill-ai/x/log"
-	"github.com/instill-ai/x/temporal"
 )
-
-var serviceName = "mgmt-backend-worker"
 
 func main() {
 	if err := config.Init(config.ParseConfigFlag()); err != nil {
@@ -78,34 +65,6 @@ func main() {
 	// Create preset organization
 	if err := preset.CreatePresetOrg(ctx, r); err != nil {
 		logger.Fatal(err.Error())
-	}
-
-	temporalClientOptions, err := temporal.ClientOptions(config.Config.Temporal, logger)
-	if err != nil {
-		logger.Fatal("Unable to build Temporal client options", zap.Error(err))
-	}
-
-	// Only add interceptor if tracing is enabled
-	if config.Config.OTELCollector.Enable {
-		temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
-			Tracer:            otel.Tracer(serviceName),
-			TextMapPropagator: otel.GetTextMapPropagator(),
-		})
-		if err != nil {
-			logger.Fatal("Unable to create temporal tracing interceptor", zap.Error(err))
-		}
-		temporalClientOptions.Interceptors = []interceptor.ClientInterceptor{temporalTracingInterceptor}
-	}
-
-	temporalClient, err := client.Dial(temporalClientOptions)
-	if err != nil {
-		logger.Fatal(fmt.Sprintf("Unable to create client: %s", err))
-	}
-	defer temporalClient.Close()
-
-	// for only local temporal cluster
-	if config.Config.Temporal.ServerRootCA == "" && config.Config.Temporal.ClientCert == "" && config.Config.Temporal.ClientKey == "" {
-		initTemporalNamespace(ctx, temporalClient, logger)
 	}
 
 }
@@ -177,45 +136,4 @@ func createDefaultUser(ctx context.Context, r repository.Repository) error {
 		return err
 	}
 	return nil
-}
-
-func initTemporalNamespace(ctx context.Context, client client.Client, logger *zap.Logger) {
-
-	resp, err := client.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{})
-	if err != nil {
-		logger.Fatal(fmt.Sprintf("Unable to list namespaces: %s", err))
-	}
-
-	found := false
-	for _, n := range resp.GetNamespaces() {
-		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
-			found = true
-		}
-	}
-
-	if !found {
-		if _, err := client.WorkflowService().RegisterNamespace(ctx,
-			&workflowservice.RegisterNamespaceRequest{
-				Namespace: config.Config.Temporal.Namespace,
-				WorkflowExecutionRetentionPeriod: func() *durationpb.Duration {
-					// Check if the string ends with "d" for day.
-					s := config.Config.Temporal.Retention
-					if strings.HasSuffix(s, "d") {
-						// Parse the number of days.
-						days, err := strconv.Atoi(s[:len(s)-1])
-						if err != nil {
-							logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-						}
-						// Convert days to hours and then to a duration.
-						t := time.Hour * 24 * time.Duration(days)
-						return durationpb.New(t)
-					}
-					logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-					return nil
-				}(),
-			},
-		); err != nil {
-			logger.Fatal(fmt.Sprintf("Unable to register namespace: %s", err))
-		}
-	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -52,11 +52,8 @@ openfga:
   port: 8080
 temporal:
   hostport: temporal:7233
-  namespace: mgmt-backend
+  namespace: instill-core
   retention: 1d
   metricsport: 8096
-  servername:
-  serverrootca:
-  clientcert:
-  clientkey:
+  apikey:
   insecureskipverify:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/redis/go-redis/v9 v9.9.0
 	go.einride.tech/aip v0.70.2
 	go.opentelemetry.io/otel v1.37.0
-	go.temporal.io/api v1.49.1
 	go.temporal.io/sdk v1.34.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.6.0
 	go.uber.org/zap v1.27.0
@@ -113,6 +112,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
+	go.temporal.io/api v1.49.1 // indirect
 	go.temporal.io/sdk/contrib/tally v0.2.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,14 +18,14 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250725054026-1b6f578bcb39
 	github.com/instill-ai/usage-client v0.4.0
-	github.com/instill-ai/x v0.9.0-alpha
+	github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2
 	github.com/openfga/go-sdk v0.7.1
 	github.com/redis/go-redis/v9 v9.9.0
 	go.einride.tech/aip v0.70.2
 	go.opentelemetry.io/otel v1.37.0
-	go.temporal.io/sdk v1.34.0
+	go.temporal.io/sdk v1.35.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.6.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.39.0
@@ -112,7 +112,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
-	go.temporal.io/api v1.49.1 // indirect
+	go.temporal.io/api v1.51.0 // indirect
 	go.temporal.io/sdk/contrib/tally v0.2.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250725054026-1b6f578bcb39 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250725054026-1b6f578bcb39/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
-github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=
-github.com/instill-ai/x v0.9.0-alpha/go.mod h1:vAzbuQ7HAWdQkkpDq9mvWjSXQEJZSgJhguN6NhpLTUk=
+github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc h1:rzg5semefqYy7AuYBAJp16P96c6fs9r3Y1d7OeSrGk4=
+github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc/go.mod h1:OaBzHZhIBfrngDMxWbyTPSd1gILO2vrndi5z/tFpCSk=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -503,11 +503,11 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v1.7.0 h1:jX1VolD6nHuFzOYso2E73H85i92Mv8JQYk0K9vz09os=
 go.opentelemetry.io/proto/otlp v1.7.0/go.mod h1:fSKjH6YJ7HDlwzltzyMj036AJ3ejJLCgCSHGj4efDDo=
 go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
-go.temporal.io/api v1.49.1 h1:CdiIohibamF4YP9k261DjrzPVnuomRoh1iC//gZ1puA=
-go.temporal.io/api v1.49.1/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.51.0 h1:9+e14GrIa7nWoWoudqj/PSwm33yYjV+u8TAR9If7s/g=
+go.temporal.io/api v1.51.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
-go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
-go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
+go.temporal.io/sdk v1.35.0 h1:lRNAQ5As9rLgYa7HBvnmKyzxLcdElTuoFJ0FXM/AsLQ=
+go.temporal.io/sdk v1.35.0/go.mod h1:1q5MuLc2MEJ4lneZTHJzpVebW2oZnyxoIOWX3oFVebw=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0 h1:rNBArDj5iTUkcMwKocUShoAW59o6HdS7Nq4CTp4ldj8=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0/go.mod h1:Lem8VrE2ks8P+FYcRM3UphPoBr+tfM3v/Kaf0qStzSg=
 go.temporal.io/sdk/contrib/tally v0.2.0 h1:XnTJIQcjOv+WuCJ1u8Ve2nq+s2H4i/fys34MnWDRrOo=


### PR DESCRIPTION
Because

- The Temporal namespace will now be initialized when the Temporal service starts.
Ref: https://github.com/instill-ai/instill-core/pull/1352
- We now use the shared `instill-core` namespace across all services.

This commit

- Removes Temporal namespace initialization
- Adopts the latest `x/temporal` package to support API key authentication for connecting to Temporal Cloud