### PR TITLE
fix(usage): fix usage admin user nonexist issue

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -12,6 +12,7 @@ import (
 	"go.einride.tech/aip/filtering"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"gorm.io/gorm/logger"
 	"gorm.io/plugin/dbresolver"
 
 	"github.com/instill-ai/mgmt-backend/config"
@@ -306,6 +307,11 @@ func (r *repository) createOwner(ctx context.Context, ownerType string, owner *d
 
 func (r *repository) GetOwner(ctx context.Context, id string, includeAvatar bool) (*datamodel.Owner, error) {
 	db := r.CheckPinnedUser(ctx, r.db)
+
+	// Temporarily disable logging for admin ID queries
+	if id == "admin" {
+		db = db.Session(&gorm.Session{Logger: db.Logger.LogMode(logger.Silent)})
+	}
 
 	var owner datamodel.Owner
 	queryBuilder := db.Model(&datamodel.Owner{}).Where("id = ?", id)

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gofrs/uuid"
+	"go.einride.tech/aip/filtering"
+
 	"github.com/instill-ai/mgmt-backend/config"
 	"github.com/instill-ai/mgmt-backend/pkg/constant"
 	"github.com/instill-ai/mgmt-backend/pkg/service"
-	"go.einride.tech/aip/filtering"
 
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	usagepb "github.com/instill-ai/protogen-go/core/usage/v1beta"
@@ -38,7 +40,9 @@ func NewUsage(ctx context.Context, s service.Service, usc usagepb.UsageServiceCl
 	if user, err := s.GetUserAdmin(ctx, constant.DefaultUserID); err == nil {
 		defaultOwnerUID = *user.Uid
 	} else {
-		logger.Error(err.Error())
+		// Only Instill Core CE has the default user "admin"
+		logger.Debug(fmt.Sprintf("error getting default user: %v, use a zero uuid as default owner uid", err))
+		defaultOwnerUID = uuid.Nil.String()
 	}
 
 	reporter, err := usageclient.InitReporter(ctx, usc, usagepb.Session_SERVICE_MGMT, config.Config.Server.Edition, serviceVersion, defaultOwnerUID)
@@ -116,7 +120,9 @@ func (u *usage) StartReporter(ctx context.Context) {
 	if user, err := u.service.GetUserAdmin(ctx, constant.DefaultUserID); err == nil {
 		defaultOwnerUID = *user.Uid
 	} else {
-		logger.Error(err.Error())
+		// Only Instill Core CE has the default user "admin"
+		logger.Debug(fmt.Sprintf("error getting default user: %v, use a zero uuid as default owner uid", err))
+		defaultOwnerUID = uuid.Nil.String()
 	}
 
 	go func() {


### PR DESCRIPTION
Because

- when the default `admin` doesn't exist, the usage logic will constantly log errors.

This commit

- fixes the issue and assign `defaultOwnerUID` with zero UUID to indicate the nonexistent real user in the usage database.
