### PR TITLE
fix(middleware,repository): fix user profile avatar issue

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -87,7 +87,7 @@ jobs:
           context: mgmt-backend
           load: true
           build-args: |
-            SERVICE_NAME=mgmt-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/mgmt-backend:${{ env.COMMIT_SHORT_SHA }}
           cache-from: |

--- a/pkg/handler/publichandler.go
+++ b/pkg/handler/publichandler.go
@@ -29,7 +29,7 @@ import (
 
 // TODO: Validate mask based on the field behavior. Currently, the fields are hard-coded.
 // We stipulate that the ID of the user is IMMUTABLE
-var outputOnlyFields = []string{"name", "type", "create_time", "update_time", "customer_id"}
+var outputOnlyFields = []string{"name", "create_time", "update_time", "customer_id"}
 var immutableFields = []string{"uid", "id"}
 
 var createRequiredFieldsForToken = []string{"id"}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -36,7 +36,7 @@ func HandleAvatar(mux *runtime.ServeMux, repository repository.Repository, w htt
 			return
 		}
 		if user.ProfileAvatar.String == "" {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		avatarBase64 = user.ProfileAvatar.String
@@ -47,7 +47,7 @@ func HandleAvatar(mux *runtime.ServeMux, repository repository.Repository, w htt
 			return
 		}
 		if org.ProfileAvatar.String == "" {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		avatarBase64 = org.ProfileAvatar.String

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -150,9 +150,11 @@ func (r *repository) GetUserByUID(ctx context.Context, uid uuid.UUID) (*datamode
 
 	return ownerWithType(owner, "user")
 }
+
 func (r *repository) UpdateUser(ctx context.Context, id string, user *datamodel.Owner) error {
 	return r.updateOwner(ctx, "user", id, user)
 }
+
 func (r *repository) DeleteUser(ctx context.Context, id string) error {
 	return r.deleteOwner(ctx, "user", id)
 }
@@ -341,7 +343,7 @@ func (r *repository) updateOwner(ctx context.Context, ownerType string, id strin
 	db := r.CheckPinnedUser(ctx, r.db)
 
 	logger, _ := logx.GetZapLogger(ctx)
-	if result := db.Select("*").Omit("UID").Omit("password_hash").Model(&datamodel.Owner{}).Where("owner_type = ?", ownerType).Where("id = ?", id).Updates(owner); result.Error != nil {
+	if result := db.Omit("UID").Omit("password_hash").Model(&datamodel.Owner{}).Where("owner_type = ?", ownerType).Where("id = ?", id).Updates(owner); result.Error != nil {
 		logger.Error(result.Error.Error())
 		return result.Error
 	}


### PR DESCRIPTION
Because

- the backend should return `204` instead of `404` when the user avatar hasn't been uploaded yet.
- updating user fields without touching profile.avatar was wiping the avatar due to DB updates writing zero-values.

This commit

- change the response status accordingly.
- Updates `pkg/repository/repository.go` to remove `.Select("*")` in `updateOwner`, letting gorm skip zero-value fields (prevents unintended clearing of `profile.avatar` and similar fields).